### PR TITLE
fix: Panic when reading incorrect messages

### DIFF
--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -302,7 +302,7 @@ impl DekuContainerRead<'_> for Message {
             reader.skip_bits(input.1)?;
         }
 
-        let value = Self::from_reader_with_ctx(reader, ()).unwrap();
+        let value = Self::from_reader_with_ctx(reader, ())?;
 
         Ok((reader.bits_read, value))
     }


### PR DESCRIPTION
## PR Description

This PR adds a minor change to avoid the application using the library to crash when it attempts to read an incorrect message.