### PR TITLE
allow to specify which rtlsdr to use

### DIFF
--- a/crates/jet1090/src/cli.rs
+++ b/crates/jet1090/src/cli.rs
@@ -91,9 +91,11 @@ impl Source {
         if let Address::Rtlsdr(args) = &self.address {
             #[cfg(not(feature = "rtlsdr"))]
             {
-                eprintln!(
-                    "Not compiled with RTL-SDR support, use the rtlsdr feature"
+                error!(
+                    "rtlsdr://{} ignored",
+                    args.clone().unwrap_or("".to_string())
                 );
+                eprintln!("Compile jet1090 with the rtlsdr feature");
                 std::process::exit(127);
             }
             #[cfg(feature = "rtlsdr")]

--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -186,7 +186,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(feature = "rtlsdr")]
     if let Some(args) = cli_options.discover {
-        rtlsdr::enumerate(&format!("driver={args}"));
+        rtlsdr::enumerate(&args.to_string());
         return Ok(());
     }
 

--- a/crates/rs1090/examples/rtlsdr.rs
+++ b/crates/rs1090/examples/rtlsdr.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "rtlsdr")]
 use soapysdr::{enumerate, Device};
+#[cfg(feature = "rtlsdr")]
 use tracing::info;
 
+#[cfg(feature = "rtlsdr")]
 fn main() {
     let device = enumerate("driver=rtlsdr").unwrap();
     for arg in device {

--- a/crates/rs1090/examples/rtlsdr.rs
+++ b/crates/rs1090/examples/rtlsdr.rs
@@ -1,0 +1,21 @@
+use soapysdr::{enumerate, Device};
+use tracing::info;
+
+fn main() {
+    let device = enumerate("driver=rtlsdr").unwrap();
+    for arg in device {
+        println!("{:#}", arg);
+
+        let device = match Device::new(arg) {
+            Ok(device) => {
+                info!("{:#}", device.hardware_info().unwrap());
+                device
+            }
+            Err(error) => {
+                eprintln!("SoapySDR error: {}", error);
+                std::process::exit(127);
+            }
+        };
+        println!("{:#}", device.hardware_info().unwrap());
+    }
+}

--- a/crates/rs1090/examples/rtlsdr.rs
+++ b/crates/rs1090/examples/rtlsdr.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "rtlsdr")]
 use soapysdr::{enumerate, Device};
-#[cfg(feature = "rtlsdr")]
 use tracing::info;
 
 #[cfg(feature = "rtlsdr")]
@@ -21,4 +20,9 @@ fn main() {
         };
         println!("{:#}", device.hardware_info().unwrap());
     }
+}
+
+#[cfg(not(feature = "rtlsdr"))]
+fn main() {
+    info!("rtlsdr feature not activated");
 }


### PR DESCRIPTION
By default, all rtl-sdr may have the same serial number, but you may adjust it with `rtl_eeprom -d 0 -s <new_serial>`