### PR TITLE
New data model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/crates/decode1090/src/main.rs
+++ b/crates/decode1090/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 timestamp: json.timestamp,
                 frame: json.frame,
                 message,
-                metadata: metadata,
+                metadata,
                 decode_time: None,
             };
             if let Some(message) = &mut msg.message {

--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -14,6 +14,7 @@ use crossterm::event::KeyCode;
 use ratatui::widgets::*;
 use redis::AsyncCommands;
 use rs1090::decode::cpr::{decode_position, AircraftState};
+use rs1090::decode::serialize_decode_time;
 use rs1090::prelude::*;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -65,6 +66,9 @@ struct Options {
     /// Should we update the reference positions (if the receiver is moving)
     #[arg(short, long, default_value=None)]
     update_position: bool,
+
+    #[arg(long)]
+    stats: Option<bool>,
 
     /// Shell completion generation
     #[arg(long = "completion", value_enum)]
@@ -175,6 +179,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     if cli_options.redis_topic.is_some() {
         options.redis_topic = cli_options.redis_topic;
+    }
+    if cli_options.stats.is_some() {
+        options.stats = cli_options.stats;
+    }
+    if options.stats.unwrap_or(false) {
+        serialize_decode_time();
     }
 
     options.sources.append(&mut cli_options.sources);

--- a/crates/jet1090/src/table.rs
+++ b/crates/jet1090/src/table.rs
@@ -377,8 +377,13 @@ impl Render for ColumnRender {
                 s.nacp.map(|v| format!("{}", v)).unwrap_or("".to_string())
             }
             Self::COUNT => s.count.to_string(),
-            Self::REFERENCE => s.airport.clone().unwrap_or("".to_string()),
-            // s.reference.to_string(),
+            Self::REFERENCE => s
+                .metadata
+                .first()
+                .unwrap()
+                .name
+                .clone()
+                .unwrap_or("".to_string()),
             Self::LAST => {
                 if now > s.last + 5 {
                     format!("{}s ago", now - s.last)
@@ -471,7 +476,7 @@ impl Render for ColumnRender {
             ColumnRender::ROLL => Constraint::Length(5),
             ColumnRender::NACP => Constraint::Length(3),
             ColumnRender::COUNT => Constraint::Length(8),
-            ColumnRender::REFERENCE => Constraint::Length(4),
+            ColumnRender::REFERENCE => Constraint::Length(8),
             ColumnRender::LAST => Constraint::Length(7),
             ColumnRender::FIRST => Constraint::Length(5),
         }

--- a/crates/rs1090/examples/flight.rs
+++ b/crates/rs1090/examples/flight.rs
@@ -1,6 +1,5 @@
 use rayon::prelude::*;
 use rs1090::decode::cpr::{decode_positions, Position};
-use rs1090::decode::TimeSource;
 use rs1090::prelude::*;
 
 use std::env;
@@ -68,11 +67,10 @@ fn main() -> io::Result<()> {
                 let (_, msg) = Message::from_bytes((&bytes, 0)).unwrap();
                 res.push(TimedMessage {
                     timestamp,
-                    timesource: TimeSource::External,
-                    rssi: None,
-                    frame: hex.to_string(),
+                    frame: bytes,
                     message: Some(msg),
-                    idx: 0,
+                    metadata: vec![],
+                    decode_time: None,
                 });
             }
             res

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -488,6 +488,7 @@ pub struct SensorMetadata {
     /// The identifier of the receptor
     pub serial: u64,
     /// A possible name for the receptor
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -493,9 +493,7 @@ pub struct SensorMetadata {
 
 static mut SERIALIZE_DECODE_TIME: bool = false;
 fn skip_serialize_decode_time(field: &Option<f64>) -> bool {
-    unsafe {
-        return !SERIALIZE_DECODE_TIME | field.is_none();
-    }
+    unsafe { !SERIALIZE_DECODE_TIME | field.is_none() }
 }
 pub fn serialize_decode_time() {
     unsafe { SERIALIZE_DECODE_TIME = true };

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -491,6 +491,16 @@ pub struct SensorMetadata {
     pub name: Option<String>,
 }
 
+static mut SERIALIZE_DECODE_TIME: bool = false;
+fn skip_serialize_decode_time(field: &Option<f64>) -> bool {
+    unsafe {
+        return !SERIALIZE_DECODE_TIME | field.is_none();
+    }
+}
+pub fn serialize_decode_time() {
+    unsafe { SERIALIZE_DECODE_TIME = true };
+}
+
 #[derive(Serialize)]
 pub struct TimedMessage {
     /// The timestamp (in s) of the first time the message was received
@@ -504,7 +514,7 @@ pub struct TimedMessage {
     /// Information about when and where the message was received
     pub metadata: Vec<SensorMetadata>,
     /// Debugging information about decoding time (not serialized)
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "skip_serialize_decode_time")]
     pub decode_time: Option<f64>,
 }
 

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -9,7 +9,7 @@ use adsb::{ADSB, ME};
 use commb::{DF20DataSelector, DF21DataSelector};
 use crc::modes_checksum;
 use deku::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use tracing::debug;
 
@@ -475,42 +475,58 @@ impl fmt::Display for Message {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TimeSource {
-    /// The timestamp is provided by the system when it receives the message
-    System,
-    /// The timestamp is provided by the GPS in the header of the message
-    Radarcape,
-    /// The timestamp is provided by the user asking to decode the message
-    External,
-}
-
-fn is_zero(value: &usize) -> bool {
-    *value == 0
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SensorMetadata {
+    /// The timestamp when the message was received by the receptor
+    pub system_timestamp: f64,
+    /// The GNSS timestamp of the message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gnss_timestamp: Option<f64>,
+    /// The signal level
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rssi: Option<f64>,
+    /// The identifier of the receptor
+    pub serial: u64,
+    /// A possible name for the receptor
+    pub name: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct TimedMessage {
+    /// The timestamp (in s) of the first time the message was received
     pub timestamp: f64,
-
-    pub timesource: TimeSource,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rssi: Option<f64>,
-
-    pub frame: String,
-
+    /// The message payload
+    #[serde(serialize_with = "as_hex", deserialize_with = "from_hex")]
+    pub frame: Vec<u8>,
+    /// The decoded message
     #[serde(flatten)]
     pub message: Option<Message>,
+    /// Information about when and where the message was received
+    pub metadata: Vec<SensorMetadata>,
+    /// Debugging information about decoding time (not serialized)
+    #[serde(skip)]
+    pub decode_time: Option<f64>,
+}
 
-    #[serde(skip_serializing_if = "is_zero")]
-    pub idx: usize,
+pub fn as_hex<S>(data: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let hex_string = hex::encode(data);
+    serializer.serialize_str(&hex_string)
+}
+
+pub fn from_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let hex_string = String::deserialize(deserializer)?; // Deserialize as a string
+    hex::decode(&hex_string).map_err(serde::de::Error::custom) // Decode and handle errors
 }
 
 impl fmt::Display for TimedMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{:.5},{}", &self.timestamp, &self.frame)?;
+        writeln!(f, "{:.5},{}", &self.timestamp, hex::encode(&self.frame))?;
         if let Some(msg) = &self.message {
             writeln!(f, "{}", msg)?;
         }
@@ -519,7 +535,7 @@ impl fmt::Display for TimedMessage {
 }
 impl fmt::Debug for TimedMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{:.5},{}", &self.timestamp, &self.frame)?;
+        writeln!(f, "{:.5},{}", &self.timestamp, hex::encode(&self.frame))?;
         if let Some(msg) = &self.message {
             writeln!(f, "{:#}", msg)?;
         }

--- a/crates/rs1090/src/lib.rs
+++ b/crates/rs1090/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
     /// The root structure to decode messages
     pub use crate::decode::Message;
     pub use crate::decode::DF::*;
-    pub use crate::decode::{TimedMessage, ICAO};
+    pub use crate::decode::{SensorMetadata, TimedMessage, ICAO};
 
     /// This re-export is necessary for the following export
     pub use futures_util::stream::StreamExt;

--- a/crates/rs1090/src/source/beast.rs
+++ b/crates/rs1090/src/source/beast.rs
@@ -70,7 +70,8 @@ pub async fn next_msg(mut stream: DataSource) -> impl Stream<Item = Vec<u8>> {
                         len
                     }
                     _ => {
-                        error!("Error reading from websocket");break;
+                        error!("Error reading from websocket");
+                        break;
                     }
                 }
             }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -24,7 +24,6 @@ use rs1090::decode::bds::bds60::HeadingAndSpeedReport;
 use rs1090::decode::bds::bds65::AircraftOperationStatus;
 use rs1090::decode::cpr::{decode_positions, Position};
 use rs1090::decode::flarm::Flarm;
-use rs1090::decode::TimeSource;
 use rs1090::prelude::*;
 
 #[pyfunction]
@@ -252,11 +251,10 @@ fn decode_1090t_vec(
                     if let Ok((_, message)) = Message::from_bytes((&bytes, 0)) {
                         Some(TimedMessage {
                             timestamp,
-                            timesource: TimeSource::External,
-                            rssi: None,
-                            frame: msg.to_string(),
+                            frame: bytes,
                             message: Some(message),
-                            idx: 0,
+                            metadata: vec![],
+                            decode_time: None,
                         })
                     } else {
                         None


### PR DESCRIPTION
- new data model fitted for when messages can come from several receivers
- payload stored as `Vec<u8>`
- also `~` is now accepted in path for configuration file and output file
- `--expire` becomes `--history-expire`
- messages are decoded in their async task to benefit from potential multi-thread/core
- new option `--stats true` to explore statistics