### PR TITLE
Switch to stdout for tui, configure_logging for soapysdr

### DIFF
--- a/crates/jet1090/src/tui.rs
+++ b/crates/jet1090/src/tui.rs
@@ -3,22 +3,22 @@ use crossterm::execute;
 use crossterm::terminal::*;
 use futures::{FutureExt, StreamExt};
 use ratatui::prelude::*;
-use std::io::{self, stderr, Stderr};
+use std::io::{self, stdout, Stdout};
 use tokio::sync::mpsc;
 
 /// A type alias for the terminal type used in this application
-pub type Tui = Terminal<CrosstermBackend<Stderr>>;
+pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
 /// Initialize the terminal
 pub fn init() -> io::Result<Tui> {
-    execute!(stderr(), EnterAlternateScreen)?;
+    execute!(stdout(), EnterAlternateScreen)?;
     enable_raw_mode()?;
-    Terminal::new(CrosstermBackend::new(stderr()))
+    Terminal::new(CrosstermBackend::new(stdout()))
 }
 
 /// Restore the terminal to its original state
 pub fn restore() -> io::Result<()> {
-    execute!(stderr(), LeaveAlternateScreen)?;
+    execute!(stdout(), LeaveAlternateScreen)?;
     disable_raw_mode()?;
     Ok(())
 }

--- a/crates/rs1090/src/source/rtlsdr.rs
+++ b/crates/rs1090/src/source/rtlsdr.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use num_complex::Complex;
-use soapysdr::{Args, Device, Direction};
+use soapysdr::{configure_logging, Args, Device, Direction};
 use tokio::sync::mpsc;
 
 use crate::decode::crc::modes_checksum;
@@ -32,6 +32,7 @@ pub async fn receiver<A: Into<Args> + fmt::Display + std::marker::Copy>(
         }
         None => info!("Trying to connect rtlsdr with options: driver=rtlsdr"),
     }
+    configure_logging();
     let device = match args {
         None => Device::new("driver=rtlsdr"),
         Some(args) => Device::new(args),


### PR DESCRIPTION
Since `librtlsdr` force logs some stuff to stderr, and RUST_LOG by default also uses stderr, switch to stdout for the TUI.

This allows users to manually redirect stderr to e.g `/dev/null` (or an actual file they're `tail`ing), to avoid weird log messages from breaking the TUI.

Future improvement could be to capture `stderr` and render it as a separate "view logs" window within the TUI.

Addresses #146 