### PR TITLE
Implementation of TCP traffic tunnelled through ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -124,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "apple-bindgen"
@@ -371,9 +395,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -455,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +495,23 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bindgen"
@@ -542,6 +589,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +608,16 @@ dependencies = [
  "futures-io",
  "futures-lite 2.5.0",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -568,9 +634,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
@@ -613,6 +679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +718,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "chrono"
@@ -820,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,13 +1066,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1106,6 +1247,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1236,10 +1389,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1351,6 +1563,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixedbitset"
@@ -1520,6 +1748,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1536,6 +1765,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1785,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1670,10 +1920,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hexlit"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6e75c860d4216ac53f9ac88b25c99eaedba075b3a7b2ed31f2adc51a74fffd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2056,6 +2321,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2219,6 +2485,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -2326,6 +2595,48 @@ checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
  "byteorder",
  "crc",
+]
+
+[[package]]
+name = "makiko"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bce09e9319c05a058a24aa52a6a0ccfece0424b8d7caf03710bdad6a553be8d"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "base64 0.22.1",
+ "bcrypt-pbkdf",
+ "bytes",
+ "cbc",
+ "chacha20",
+ "ctr",
+ "derivative",
+ "ecdsa",
+ "ed25519-dalek",
+ "futures-core",
+ "hex-literal",
+ "hmac",
+ "log",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "parking_lot",
+ "pem",
+ "pin-project",
+ "pkcs8",
+ "poly1305",
+ "rand",
+ "rand_chacha",
+ "regex",
+ "regex-syntax 0.8.5",
+ "rsa",
+ "sha-1",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -2514,6 +2825,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,12 +2867,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2577,6 +2918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2944,30 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -2648,6 +3019,25 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2706,6 +3096,44 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.3.0",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core",
+ "spki",
 ]
 
 [[package]]
@@ -2787,6 +3215,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +3276,15 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3246,6 +3706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,7 +3736,9 @@ version = "0.4.7"
 dependencies = [
  "ansi_term",
  "approx",
+ "async-recursion",
  "async-stream",
+ "bytes",
  "criterion",
  "deku",
  "dirs",
@@ -3276,6 +3748,7 @@ dependencies = [
  "hexlit",
  "libm",
  "log",
+ "makiko",
  "num-complex",
  "once_cell",
  "prost",
@@ -3285,6 +3758,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soapysdr",
+ "ssh2-config",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tonic",
@@ -3318,6 +3792,26 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3445,6 +3939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3967,31 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -3560,6 +4088,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,6 +4114,17 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -3619,6 +4169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -3689,6 +4249,30 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh2-config"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54c1f8a904a031c129e6e258994999839d6f0ffad4964062cb76d975259a0d8"
+dependencies = [
+ "bitflags 2.6.0",
+ "dirs",
+ "glob",
+ "log",
+ "thiserror 2.0.6",
+ "wildmatch",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -4369,6 +4953,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4619,6 +5213,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.42",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"
@@ -4891,6 +5491,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/jet1090/Cargo.toml
+++ b/crates/jet1090/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [features]
 rtlsdr = ['rs1090/rtlsdr']
 sero = ['rs1090/sero']
+ssh = ['rs1090/ssh']
 
 [dependencies]
 chrono = "0.4.40"

--- a/crates/rs1090/Cargo.toml
+++ b/crates/rs1090/Cargo.toml
@@ -12,10 +12,13 @@ edition.workspace = true
 [features]
 rtlsdr = ['soapysdr']
 sero = ['prost', 'tonic', 'dirs', 'reqwest']
+ssh = ['makiko', 'ssh2-config', 'dirs', 'async-recursion', 'bytes']
 
 [dependencies]
 ansi_term = "0.12.1"
+async-recursion = { version = "1.1.1", optional = true }
 async-stream = "0.3.6"
+bytes = { version = "1.10.1", optional = true }
 deku = { version = "0.18.1", features = ["logging"] }
 dirs = { version = "6.0.0", optional = true }
 futures = "0.3.31"
@@ -23,15 +26,19 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 libm = "0.2.11"
 log = "0.4.26"
+makiko = { version = "0.2.4", optional = true }
 num-complex = "0.4.5"
 once_cell = "1.21.1"
 prost = { version = "0.13.5", optional = true }
 rayon = "1.9.0"
 regex = "1.11.1"
-reqwest = { version = "0.12.9", optional = true, default-features = false, features = [ "rustls-tls" ] }
+reqwest = { version = "0.12.9", optional = true, default-features = false, features = [
+    "rustls-tls",
+] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 soapysdr = { version = "0.4.1", optional = true }
+ssh2-config = { version = "0.4.0", optional = true }
 tonic = { version = "0.12.3", features = ["tls"], optional = true }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/rs1090/src/source/mod.rs
+++ b/crates/rs1090/src/source/mod.rs
@@ -6,3 +6,8 @@ pub mod rtlsdr;
 
 #[cfg(feature = "sero")]
 pub mod sero;
+
+#[cfg(feature = "ssh")]
+pub mod sshjump;
+#[cfg(feature = "ssh")]
+pub mod sshtunnel;

--- a/crates/rs1090/src/source/sshjump.rs
+++ b/crates/rs1090/src/source/sshjump.rs
@@ -1,0 +1,255 @@
+use log::{info, warn};
+use makiko::{
+    ChannelConfig, Client, ClientConfig, ClientReceiver, Privkey,
+    TunnelReceiver,
+};
+use ssh2_config::{ParseRule, SshConfig};
+use std::fs::File;
+use std::io::BufReader;
+use tokio::net::TcpStream;
+
+use crate::source::sshtunnel::SshTunnelIo;
+
+pub struct TunnelledTcp {
+    pub address: String,
+    pub port: u16,
+    pub jump: String,
+}
+
+async fn authenticate_server(
+    mut client_rx: ClientReceiver,
+    host: String,
+    port: u16,
+) {
+    let mut hosts_path = dirs::home_dir().unwrap();
+    hosts_path.push(".ssh");
+    hosts_path.push("known_hosts");
+
+    let hosts_data =
+        std::fs::read(&hosts_path).expect("Could not read known_hosts file");
+
+    let mut hosts_file = makiko::host_file::File::decode(hosts_data.into());
+
+    loop {
+        // Wait for the next event.
+        let event = client_rx
+            .recv()
+            .await
+            .expect("Error while receiving client event");
+
+        // Exit the loop when the client has closed.
+        let Some(event) = event else { break };
+
+        if let makiko::ClientEvent::ServerPubkey(pubkey, accept) = event {
+            info!(
+                "Server pubkey type {}, fingerprint {}",
+                pubkey.type_str(),
+                pubkey.fingerprint()
+            );
+
+            match hosts_file.match_host_port_key(&host, port, &pubkey) {
+                makiko::host_file::KeyMatch::Accepted(entries) => {
+                    info!("Found the server key in known_hosts file");
+                    for entry in entries.iter() {
+                        info!("At line {}", entry.line());
+                    }
+                    accept.accept();
+                }
+                makiko::host_file::KeyMatch::Revoked(_entry) => {
+                    panic!("The server key was revoked in known_hosts file");
+                }
+                makiko::host_file::KeyMatch::OtherKeys(entries) => {
+                    warn!("The known_hosts file specifies other keys for this server:");
+                    for entry in entries.iter() {
+                        println!(
+                            "At line {}, pubkey type {}, fingerprint {}",
+                            entry.line(),
+                            entry.pubkey().type_str(),
+                            entry.pubkey().fingerprint()
+                        );
+                    }
+                    panic!("Aborting, you might be target of a man-in-the-middle attack!");
+                }
+                makiko::host_file::KeyMatch::NotFound => {
+                    info!("Did not find any key for this server in known_hosts file, \
+                            adding it to the file");
+
+                    accept.accept();
+
+                    hosts_file.append_entry(
+                        makiko::host_file::File::entry_builder()
+                            .host_port(&host, port)
+                            .key(pubkey),
+                    );
+                    let hosts_data = hosts_file.encode();
+                    std::fs::write(&hosts_path, &hosts_data).expect(
+                        "Could not write the modified known_hosts file",
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn authenticate_by_private_key(
+    client: &Client,
+    user: &str,
+    privkey: &Privkey,
+) {
+    let pubkey = privkey.pubkey();
+    for pubkey_algo in pubkey.algos().iter().copied() {
+        // Check whether this combination of a public key and algorithm would be
+        // acceptable to the server.
+        if client
+            .check_pubkey(user.to_string(), &pubkey, pubkey_algo)
+            .await
+            .expect("Error when checking a public key")
+        {
+            // Try to authenticate with the private key
+            let auth_res = client
+                .auth_pubkey(user.to_string(), privkey.clone(), pubkey_algo)
+                .await
+                .expect("Error when trying to authenticate");
+
+            // Deal with the possible outcomes of public key authentication.
+            match auth_res {
+                makiko::AuthPubkeyResult::Success => {
+                    info!("We have successfully authenticated using a private key");
+                    return;
+                }
+                makiko::AuthPubkeyResult::Failure(failure) => {
+                    info!(
+                        "The server rejected authentication with {:?}: {:?}",
+                        pubkey_algo, failure
+                    );
+                }
+            }
+        }
+    }
+    panic!("The server does not accept the public key");
+}
+
+fn get_params() -> SshConfig {
+    let config_path = dirs::home_dir().unwrap().join(".ssh").join("config");
+
+    let err_msg = format!("{:?} does not exist", config_path);
+    let mut reader = BufReader::new(File::open(&config_path).expect(&err_msg));
+
+    SshConfig::default()
+        .parse(
+            &mut reader,
+            ParseRule::ALLOW_UNKNOWN_FIELDS
+                | ParseRule::ALLOW_UNSUPPORTED_FIELDS,
+        )
+        .unwrap_or_else(|_| {
+            panic!("Failed to parse configuration file {:?}", config_path)
+        })
+}
+
+fn get_default_username() -> String {
+    #[cfg(target_os = "windows")]
+    let username = std::env::var("USERNAME").unwrap_or_else(|_| {
+        panic!("Could not determine the current Windows user name")
+    });
+    #[cfg(not(target_os = "windows"))]
+    let username = std::env::var("USER").unwrap_or_else(|_| {
+        panic!("Could not determine the current user name")
+    });
+    username
+}
+
+enum Io {
+    Tcp(TcpStream),
+    Tunnel(SshTunnelIo),
+}
+
+#[async_recursion::async_recursion]
+async fn connect_server(
+    server: &str,
+    params: &SshConfig,
+) -> Result<Client, Box<dyn std::error::Error>> {
+    let server_params = params.query(server);
+    let hostname = server_params.host_name.unwrap();
+    let port = server_params.port.unwrap_or(22);
+    let user = server_params.user.unwrap_or(get_default_username());
+
+    let io = match server_params.unsupported_fields.get("proxyjump") {
+        None => Io::Tcp(TcpStream::connect((hostname.to_owned(), port)).await?),
+        Some(jump) => {
+            let jump_server = jump.first().expect("No jump host specified");
+            let jump_client = connect_server(jump_server, params).await?;
+            let channel_config = ChannelConfig::default();
+            let origin_addr = ("127.0.0.1".into(), 0);
+            let (tunnel, tunnel_rx) = jump_client
+                .connect_tunnel(
+                    channel_config,
+                    (hostname.to_owned(), port),
+                    origin_addr,
+                )
+                .await
+                .expect("Could not open a tunnel");
+            Io::Tunnel(SshTunnelIo::new(tunnel, tunnel_rx))
+        }
+    };
+
+    let config = ClientConfig::default();
+    let (client, client_rx) = match io {
+        Io::Tcp(socket) => {
+            let (client, client_rx, client_fut) = Client::open(socket, config)?;
+            tokio::spawn(async move {
+                client_fut.await.expect("Error in client future");
+            });
+            (client, client_rx)
+        }
+        Io::Tunnel(io) => {
+            let (client, client_rx, client_fut) = Client::open(io, config)?;
+
+            tokio::spawn(async move {
+                client_fut.await.expect("Error in client future");
+            });
+            (client, client_rx)
+        }
+    };
+
+    tokio::task::spawn(authenticate_server(client_rx, hostname, port));
+
+    // TODO try several keys
+    let identity_files = server_params.identity_file.unwrap();
+    let privkey = tokio::fs::read(identity_files.first().unwrap()).await?;
+    let privkey = match std::env::var("SSH_PASSPHRASE").ok() {
+        None => makiko::keys::decode_pem_privkey_nopass(&privkey)
+            .expect("could not decode a private key from pem")
+            .privkey()
+            .cloned()
+            .expect("Private key is encrypted"),
+        Some(passphrase) => {
+            makiko::keys::decode_pem_privkey(&privkey, passphrase.as_bytes())
+                .expect("could not decode a private key with passphrase")
+        }
+    };
+
+    authenticate_by_private_key(&client, &user, &privkey).await;
+
+    Ok(client)
+}
+
+impl TunnelledTcp {
+    pub async fn connect(
+        &self,
+    ) -> Result<TunnelReceiver, Box<dyn std::error::Error>> {
+        let params = get_params();
+
+        let target_client = connect_server(&self.jump, &params).await?;
+
+        let channel_config = makiko::ChannelConfig::default();
+        let connect_addr = (self.address.to_owned(), self.port);
+        let origin_addr = ("0.0.0.0".into(), 0);
+
+        let (_tunnel, tunnel_rx) = target_client
+            .connect_tunnel(channel_config, connect_addr, origin_addr)
+            .await
+            .expect("Could not open a tunnel");
+
+        Ok(tunnel_rx)
+    }
+}

--- a/crates/rs1090/src/source/sshtunnel.rs
+++ b/crates/rs1090/src/source/sshtunnel.rs
@@ -1,0 +1,173 @@
+use bytes::BytesMut;
+use futures::future::BoxFuture;
+use futures::pin_mut;
+use makiko::{Tunnel, TunnelReceiver};
+use std::future::Future;
+use std::io::{Error, ErrorKind};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub struct SshTunnelIo {
+    /// The part of the tunnel used for sending data
+    /// needs to be Arc-ed for when it is part of the BoxFuture below
+    tunnel: Arc<Tunnel>,
+    /// The listening part of the tunnel for receiving data
+    tunnel_rx: TunnelReceiver,
+    /// When data is received and doesn't fit the buffer, it may be stored here
+    pending_read: Option<BytesMut>,
+    /// The future for sending data, waiting to be polled
+    pending_write_fut: Option<BoxFuture<'static, Result<(), makiko::Error>>>,
+    /// The size of the data waiting to be sent, stored to be able to return
+    /// Ok(self.pending_write_size)
+    pending_write_size: usize,
+}
+
+impl SshTunnelIo {
+    pub fn new(tunnel: Tunnel, tunnel_rx: TunnelReceiver) -> Self {
+        Self {
+            tunnel: Arc::new(tunnel),
+            tunnel_rx,
+            pending_read: None,
+            pending_write_fut: None,
+            pending_write_size: 0,
+        }
+    }
+    /// The async function needs to have not &mut self as parameters
+    async fn send_in_tunnel(
+        tunnel: Arc<Tunnel>,
+        buf: Vec<u8>,
+    ) -> Result<(), makiko::Error> {
+        tunnel.send_data(buf.into()).await
+    }
+
+    /// A wrapper to send data and store the future in the structure
+    fn send(&mut self, buf: &[u8]) -> usize {
+        self.pending_write_fut = Some(Box::pin(Self::send_in_tunnel(
+            self.tunnel.clone(),
+            buf.to_vec(),
+        )));
+        buf.len()
+    }
+}
+
+impl AsyncWrite for SshTunnelIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let this = self.get_mut();
+        if this.pending_write_fut.is_none() {
+            this.pending_write_size = this.send(buf);
+            // do not reply now, monitor the status
+        }
+
+        match this.pending_write_fut.as_mut().unwrap().as_mut().poll(cx) {
+            Poll::Pending => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Ok(())) => {
+                let _ = this.pending_write_fut.take();
+                // do not send anything new yet, but we can say sending is done
+                Poll::Ready(Ok(this.pending_write_size))
+            }
+            Poll::Ready(Err(err)) => {
+                let _ = this.pending_write_fut.take();
+                Poll::Ready(Err(Error::new(ErrorKind::Other, err)))
+            }
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        // The tunnel does not require flushing.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        // Optional: if your tunnel API supports shutdown (e.g. sending an EOF),
+        // call it here. Otherwise, simply signal that shutdown is complete.
+        let send_future = self.tunnel.send_eof();
+        pin_mut!(send_future);
+        match send_future.poll(_cx) {
+            Poll::Pending => {
+                _cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) => {
+                Poll::Ready(Err(Error::new(ErrorKind::Other, e)))
+            }
+        }
+    }
+}
+
+impl AsyncRead for SshTunnelIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+
+        // First, check if there is pending data from a previous poll.
+        if let Some(mut pending) = this.pending_read.take() {
+            let to_copy = std::cmp::min(buf.remaining(), pending.len());
+            buf.put_slice(&pending[..to_copy]);
+            if to_copy < pending.len() {
+                // Save any leftover data back.
+                this.pending_read = Some(pending.split_off(to_copy));
+            }
+            return Poll::Ready(Ok(()));
+        }
+
+        // Now that we know there is none, we can listen to new data
+        match Pin::new(&mut this.tunnel_rx).poll_recv(cx) {
+            Poll::Ready(Ok(Some(event))) => {
+                match event {
+                    makiko::TunnelEvent::Data(mut data) => {
+                        // Copy as many bytes as possible into the provided buffer.
+                        let to_copy =
+                            std::cmp::min(buf.remaining(), data.len());
+                        buf.put_slice(&data[..to_copy]);
+                        if to_copy < data.len() {
+                            // Save any leftover data back.
+                            this.pending_read =
+                                Some(data.split_off(to_copy).into());
+                        }
+                        Poll::Ready(Ok(()))
+                    }
+                    makiko::TunnelEvent::Eof => {
+                        // Signal EOF by not filling any more bytes.
+                        Poll::Ready(Ok(()))
+                    }
+                    _ => {
+                        // For any other events, simply continue polling later.
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    }
+                }
+            }
+            Poll::Ready(Ok(None)) => {
+                // The stream is finished.
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                // Convert error type as needed.
+                Poll::Ready(Err(Error::new(ErrorKind::Other, e)))
+            }
+            Poll::Pending => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+}


### PR DESCRIPTION
Keeping shells open with an active ssh connection is not convenient. This may be a niche usage, hence the `ssh` feature.

This little option should help, activate with:
```
tcp = { host = ..., port = ..., jump = ... }
```
where the jump element is a key in your `.ssh/config` file.

No ssh-agent login yet, but you may put your passphrase in the `SSH_PASSPHRASE` environment variable.