### PR TITLE
Add optional country flags column to TUI

### DIFF
--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -59,6 +59,11 @@ struct Options {
     #[serde(default)]
     interactive: bool,
 
+    /// Show country flags in TUI display (only visible when width > 130)
+    #[arg(long, default_value = "false")]
+    #[serde(default)]
+    flags: bool,
+
     /// Port for the API endpoint (on 0.0.0.0)
     #[arg(long, default_value=None)]
     serve_port: Option<u16>,
@@ -201,6 +206,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     if cli_options.interactive {
         options.interactive = true;
+    }
+    if cli_options.flags {
+        options.flags = true;
     }
     if cli_options.serve_port.is_some() {
         options.serve_port = cli_options.serve_port;
@@ -376,6 +384,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         is_search_mode: false,
         search_query: "".to_string(),
         interactive_expire: options.interactive_expire.unwrap_or(30),
+        flags: options.flags,
     }));
     let app_dec = app_tui.clone();
     let app_web = app_tui.clone();
@@ -619,6 +628,7 @@ pub struct Jet1090 {
     is_search_mode: bool,
     search_query: String,
     interactive_expire: u64,
+    flags: bool,
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/crates/jet1090/src/table.rs
+++ b/crates/jet1090/src/table.rs
@@ -2,6 +2,7 @@ use chrono::prelude::*;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use regex::Regex;
+use rs1090::data::patterns::aircraft_information;
 use std::time::{SystemTime, UNIX_EPOCH};
 use style::palette::tailwind;
 
@@ -177,8 +178,12 @@ pub fn build_table(frame: &mut Frame, app: &mut Jet1090) {
                 ]
             }
             _ => {
-                vec![
-                    ICAO24,
+                let mut cols = vec![ICAO24];
+                // Insert FLAG before TAIL only when flags are enabled
+                if app.flags {
+                    cols.push(FLAG);
+                }
+                cols.extend([
                     TAIL,
                     CALLSIGN,
                     TYPECODE,
@@ -200,7 +205,8 @@ pub fn build_table(frame: &mut Frame, app: &mut Jet1090) {
                     REFERENCE,
                     LAST,
                     FIRST,
-                ]
+                ]);
+                cols
             }
         }
     };
@@ -345,6 +351,7 @@ trait Render {
 #[allow(clippy::upper_case_acronyms)]
 enum ColumnRender {
     ICAO24,
+    FLAG,
     TAIL,
     CALLSIGN,
     TYPECODE,
@@ -372,6 +379,14 @@ impl Render for ColumnRender {
     fn cell(&self, s: &Snapshot, now: u64) -> String {
         match self {
             Self::ICAO24 => s.icao24.to_string(),
+            Self::FLAG => {
+                // Get flag emoji from ICAO24 address
+                if let Ok(info) = aircraft_information(&s.icao24, None) {
+                    info.flag.unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            }
             Self::TAIL => s.registration.to_owned().unwrap_or("".to_string()),
             Self::CALLSIGN => s.callsign.to_owned().unwrap_or("".to_string()),
             Self::TYPECODE => s.typecode.to_owned().unwrap_or("".to_string()),
@@ -456,6 +471,7 @@ impl Render for ColumnRender {
     fn header(&self, sort_key: &SortKey) -> Cell<'_> {
         match self {
             ColumnRender::ICAO24 => Cell::from("icao24".to_string()),
+            ColumnRender::FLAG => Cell::from("".to_string()), // No header for flag column
             ColumnRender::TAIL => Cell::from("tail".to_string()),
             ColumnRender::CALLSIGN => {
                 let mut c = Cell::from("callsign".to_string());
@@ -512,6 +528,7 @@ impl Render for ColumnRender {
     fn constraint(&self) -> Constraint {
         match self {
             ColumnRender::ICAO24 => Constraint::Length(6),
+            ColumnRender::FLAG => Constraint::Length(2),
             ColumnRender::TAIL => Constraint::Length(8),
             ColumnRender::CALLSIGN => Constraint::Length(8),
             ColumnRender::TYPECODE => Constraint::Length(4),


### PR DESCRIPTION

Adds an optional FLAG column to the jet1090 TUI that displays country flags based on aircraft ICAO24 addresses.

### Usage

```bash
# Enable flags via CLI
jet1090 --flags

# Or in TOML configuration
[jet1090]
flags = true
```