### PR TITLE
fix: remove unused `logging` feature from `deku`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,7 +4524,6 @@ dependencies = [
  "http 1.4.0",
  "hyper-util",
  "libm",
- "log",
  "makiko",
  "num-complex",
  "once_cell",

--- a/crates/rs1090/Cargo.toml
+++ b/crates/rs1090/Cargo.toml
@@ -32,7 +32,6 @@ hex = "0.4.3"
 http = { version = "1.4.0", optional = true }
 hyper-util = { version = "0.1.19", optional = true }
 libm = "0.2.15"
-log = "0.4.29"
 makiko = { version = "0.2.5", optional = true }
 num-complex = "0.4.5"
 once_cell = "1.21.1"

--- a/crates/rs1090/src/source/ssh.rs
+++ b/crates/rs1090/src/source/ssh.rs
@@ -1,4 +1,3 @@
-use log::{info, warn};
 use makiko::{
     ChannelConfig, Client, ClientConfig, ClientReceiver, Privkey,
     TunnelReceiver, TunnelStream,
@@ -15,6 +14,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     process::{ChildStdin, ChildStdout, Command},
 };
+use tracing::{info, warn};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 


### PR DESCRIPTION
see: https://github.com/open-aviation/tangram/issues/100

Would be great if you can also release v0.4.16 after this is merged so we don't have to use `{ git = ... }` in tangram's side