### PR TITLE
feat: implement `serde::Deserialize` for `TimedMessage`

### DIFF
--- a/crates/rs1090/src/decode/adsb.rs
+++ b/crates/rs1090/src/decode/adsb.rs
@@ -1,7 +1,7 @@
 use super::bds::{bds05, bds06, bds08, bds09, bds61, bds62, bds65};
 use super::{Capability, ICAO};
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -15,7 +15,7 @@ use std::fmt;
  *
  */
 
-#[derive(Debug, PartialEq, DekuRead, Clone, Serialize)]
+#[derive(Debug, PartialEq, DekuRead, Clone, Serialize, Deserialize)]
 pub struct ADSB {
     /// The transponder capability
     #[serde(skip)]
@@ -29,7 +29,7 @@ pub struct ADSB {
     pub message: ME,
 
     /// Parity/Interrogator ID
-    #[serde(skip)]
+    #[serde(skip, default = "crate::decode::serde_default_icao_empty")]
     pub parity: ICAO,
 }
 
@@ -64,14 +64,14 @@ impl fmt::Display for ADSB {
 * | 31       | [`bds65::AircraftOperationStatus`]                |
 */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct Unused {
     #[deku(skip, pad_bits_after = "48", default = "true")]
     #[serde(skip)]
     unused: bool,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(id_type = "u8", bits = "5")]
 //#[serde(untagged)]
 #[serde(tag = "bds")]
@@ -82,7 +82,7 @@ pub enum ME {
     #[deku(id_pat = "1..=4")]
     #[serde(rename = "08")]
     BDS08 {
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         id: u8,
         #[serde(flatten)]
         #[deku(ctx = "*id")]

--- a/crates/rs1090/src/decode/bds/bds05.rs
+++ b/crates/rs1090/src/decode/bds/bds05.rs
@@ -1,7 +1,7 @@
 use crate::decode::cpr::CPRFormat;
 use crate::decode::{decode_id13, gray2alt};
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -33,7 +33,7 @@ use std::fmt;
  * - Altitude field 0x000 indicates altitude not available (DO-260B §2.2.5.1.5)
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[deku(ctx = "tc: u8")]
 pub struct AirbornePosition {
     #[deku(
@@ -51,7 +51,7 @@ pub struct AirbornePosition {
     /// (directly based on the typecode)
     pub nuc_p: u8,
 
-    #[serde(skip)]
+    #[serde(skip)] // TODO: should we really skip? serde deserialises to NoCondition
     /// Surveillance Status (bits 6-7): Indicates emergency/alert conditions.
     /// Per ICAO Doc 9871 Table A-2-6:
     pub ss: SurveillanceStatus,
@@ -219,7 +219,9 @@ impl fmt::Display for AirbornePosition {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "2")]
 /// Surveillance Status (bits 6-7): Indicates emergency/alert conditions.  
@@ -231,13 +233,14 @@ impl fmt::Display for AirbornePosition {
 ///
 /// Codes 1 and 2 take precedence over code 3.
 pub enum SurveillanceStatus {
+    #[default]
     NoCondition = 0,
     PermanentAlert = 1,
     TemporaryAlert = 2,
     SPICondition = 3,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Copy, Clone)]
 pub enum Source {
     #[serde(rename = "barometric")]
     Barometric = 0,

--- a/crates/rs1090/src/decode/bds/bds06.rs
+++ b/crates/rs1090/src/decode/bds/bds06.rs
@@ -2,7 +2,7 @@
 
 use super::super::cpr::CPRFormat;
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use tracing::debug;
 
@@ -40,7 +40,7 @@ use tracing::debug;
  * - Positional accuracy: ~1.25 meters (typical), ~3.0m near poles (±87° latitude)
  */
 
-#[derive(Debug, PartialEq, DekuRead, Serialize, Copy, Clone)]
+#[derive(Debug, PartialEq, DekuRead, Serialize, Deserialize, Copy, Clone)]
 #[deku(ctx = "tc: u8")]
 pub struct SurfacePosition {
     #[deku(skip, default = "14 - tc")]

--- a/crates/rs1090/src/decode/bds/bds08.rs
+++ b/crates/rs1090/src/decode/bds/bds08.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use tracing::{debug, trace};
 
@@ -45,7 +45,7 @@ use tracing::{debug, trace};
  * Note: ADS-B wake vortex categories differ from ICAO WTC definitions.
  */
 
-#[derive(Debug, PartialEq, DekuRead, Serialize, Clone)]
+#[derive(Debug, PartialEq, DekuRead, Serialize, Deserialize, Clone)]
 #[deku(ctx = "id: u8")]
 pub struct AircraftIdentification {
     /// Type Code Category (bits 1-5): Per ICAO Doc 9871 Table A-2-8
@@ -171,7 +171,7 @@ impl TryFrom<u8> for Typecode {
  * - ICAO WTC M ≈ ADS-B (TC=4, CA=2 or CA=3)
  * - ICAO WTC H/J ≈ ADS-B (TC=4, CA=5)
  */
-#[derive(Debug, PartialEq, Serialize, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Copy, Clone)]
 pub enum WakeVortex {
     Reserved,
 

--- a/crates/rs1090/src/decode/bds/bds09.rs
+++ b/crates/rs1090/src/decode/bds/bds09.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 use deku::prelude::*;
-use serde::ser::SerializeStruct;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -59,7 +58,7 @@ use std::fmt;
  * Note: Subtype 3 messages are very rare in practice; most aircraft report
  * ground speed (subtypes 1/2) based on GNSS position.
  */
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct AirborneVelocity {
     #[deku(bits = "3")]
     #[serde(skip)]
@@ -122,7 +121,7 @@ pub struct AirborneVelocity {
     ///   - GNSS (1): Rate based on GNSS geometric altitude
     pub vrate_src: VerticalRateSource,
 
-    #[serde(skip)]
+    #[serde(skip, default = "Sign::positive")]
     /// Vertical Rate Sign (bit 37): Per ICAO Doc 9871 Table A-2-9a
     ///   - Positive (0): Climbing (upward)
     ///   - Negative (1): Descending (downward)
@@ -154,7 +153,7 @@ pub struct AirborneVelocity {
     /// Reserved (bits 47-48): Reserved for turn indicator (not implemented)
     pub reserved: u8,
 
-    #[serde(skip)]
+    #[serde(skip, default = "Sign::positive")]
     /// GNSS Altitude Difference Sign (bit 49): Per ICAO Doc 9871 §A.2.3.5.7
     ///   - Positive (0): GNSS altitude above barometric altitude
     ///   - Negative (1): GNSS altitude below barometric altitude
@@ -215,7 +214,7 @@ fn read_geobaro<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     Ok(value)
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(ctx = "subtype: u8", id = "subtype")]
 #[serde(untagged)]
 pub enum AirborneVelocitySubType {
@@ -234,7 +233,7 @@ pub enum AirborneVelocitySubType {
     Reserved1(ReservedVelocityData),
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct ReservedVelocityData {
     #[deku(bits = "22")]
     pub reserved_data: u32,
@@ -255,6 +254,11 @@ impl Sign {
             Self::Positive => 1,
             Self::Negative => -1,
         }
+    }
+
+    // for serde(default)
+    fn positive() -> Self {
+        Self::Positive
     }
 }
 
@@ -308,9 +312,9 @@ impl fmt::Display for Sign {
 /// Ground speed and track angle computed from components:
 /// - groundspeed = √(ew_vel² + ns_vel²)
 /// - track = atan2(ew_vel, ns_vel) converted to degrees (0-360°)
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct GroundSpeedDecoding {
-    #[serde(skip)]
+    #[serde(skip, default = "Sign::positive")]
     pub ew_sign: Sign,
     #[deku(
         endian = "big",
@@ -321,7 +325,7 @@ pub struct GroundSpeedDecoding {
     )]
     #[serde(skip)]
     pub ew_vel: f64,
-    #[serde(skip)]
+    #[serde(skip, default = "Sign::positive")]
     pub ns_sign: Sign,
     #[serde(skip)]
     #[deku(
@@ -417,21 +421,24 @@ impl Serialize for AirspeedSubsonicDecoding {
     where
         S: serde::ser::Serializer,
     {
-        let mut state = serializer.serialize_struct("Message", 2)?;
-        if let Some(heading) = &self.heading {
-            state.serialize_field("heading", heading)?;
-        }
-        if let Some(airspeed) = &self.airspeed {
-            match &self.airspeed_type {
-                AirspeedType::IAS => {
-                    state.serialize_field("IAS", &airspeed)?;
-                }
-                AirspeedType::TAS => {
-                    state.serialize_field("TAS", &airspeed)?;
-                }
-            }
-        }
-        state.end()
+        AirspeedSerdeHelper::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AirspeedSubsonicDecoding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let helper = AirspeedSerdeHelper::deserialize(deserializer)?;
+        let (status_heading, heading, airspeed_type, airspeed) =
+            helper.into_components();
+        Ok(Self {
+            status_heading,
+            heading,
+            airspeed_type,
+            airspeed,
+        })
     }
 }
 
@@ -494,21 +501,80 @@ impl Serialize for AirspeedSupersonicDecoding {
     where
         S: serde::ser::Serializer,
     {
-        let mut state = serializer.serialize_struct("Message", 2)?;
-        if let Some(heading) = &self.heading {
-            state.serialize_field("heading", heading)?;
+        AirspeedSerdeHelper::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AirspeedSupersonicDecoding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let helper = AirspeedSerdeHelper::deserialize(deserializer)?;
+        let (status_heading, heading, airspeed_type, airspeed) =
+            helper.into_components();
+        Ok(Self {
+            status_heading,
+            heading: heading.map(|h| h as f32),
+            airspeed_type,
+            airspeed,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct AirspeedSerdeHelper {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    heading: Option<f64>,
+    #[serde(rename = "IAS", skip_serializing_if = "Option::is_none")]
+    ias: Option<u16>,
+    #[serde(rename = "TAS", skip_serializing_if = "Option::is_none")]
+    tas: Option<u16>,
+}
+
+impl AirspeedSerdeHelper {
+    fn into_components(self) -> (bool, Option<f64>, AirspeedType, Option<u16>) {
+        let (airspeed_type, airspeed) = if let Some(ias) = self.ias {
+            (AirspeedType::IAS, Some(ias))
+        } else if let Some(tas) = self.tas {
+            (AirspeedType::TAS, Some(tas))
+        } else {
+            (AirspeedType::IAS, None)
+        };
+        (
+            self.heading.is_some(),
+            self.heading,
+            airspeed_type,
+            airspeed,
+        )
+    }
+}
+
+impl From<&AirspeedSubsonicDecoding> for AirspeedSerdeHelper {
+    fn from(v: &AirspeedSubsonicDecoding) -> Self {
+        let (ias, tas) = match v.airspeed_type {
+            AirspeedType::IAS => (v.airspeed, None),
+            AirspeedType::TAS => (None, v.airspeed),
+        };
+        Self {
+            heading: v.heading,
+            ias,
+            tas,
         }
-        if let Some(airspeed) = &self.airspeed {
-            match &self.airspeed_type {
-                AirspeedType::IAS => {
-                    state.serialize_field("IAS", &airspeed)?;
-                }
-                AirspeedType::TAS => {
-                    state.serialize_field("TAS", &airspeed)?;
-                }
-            }
+    }
+}
+
+impl From<&AirspeedSupersonicDecoding> for AirspeedSerdeHelper {
+    fn from(v: &AirspeedSupersonicDecoding) -> Self {
+        let (ias, tas) = match v.airspeed_type {
+            AirspeedType::IAS => (v.airspeed, None),
+            AirspeedType::TAS => (None, v.airspeed),
+        };
+        Self {
+            heading: v.heading.map(|h| h as f64),
+            ias,
+            tas,
         }
-        state.end()
     }
 }
 
@@ -549,7 +615,7 @@ pub enum DirectionNS {
     NorthToSouth = 1,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "1")]
 pub enum VerticalRateSource {

--- a/crates/rs1090/src/decode/bds/bds10.rs
+++ b/crates/rs1090/src/decode/bds/bds10.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Data Link Capability Report (BDS 1,0)
@@ -113,7 +113,9 @@ use serde::Serialize;
  * Additional implementation guidelines: ICAO Annex 10, Vol IV, §4.3.8.4.2.2.2
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "10")]
 pub struct DataLinkCapability {
     /// BDS Code (bits 1-8): Per ICAO Doc 9871 Table A-2-16  

--- a/crates/rs1090/src/decode/bds/bds17.rs
+++ b/crates/rs1090/src/decode/bds/bds17.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Common Usage GICB Capability Report (BDS 1,7)
@@ -67,7 +67,9 @@ use serde::Serialize;
  * Reference: ICAO Doc 9871 Table A-2-23
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "17")]
 pub struct CommonUsageGICBCapabilityReport {
     #[deku(bits = "1")]

--- a/crates/rs1090/src/decode/bds/bds18.rs
+++ b/crates/rs1090/src/decode/bds/bds18.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Mode S Specific Services GICB Capability Report Part 1 (BDS 1,8)
@@ -24,7 +24,7 @@ use serde::Serialize;
  * Reference: ICAO Doc 9871 Table A-2-24, §3.1.2.6.10.2
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[serde(tag = "bds", rename = "18")]
 pub struct GICBCapabilityReportPart1 {
     #[deku(bits = "1", map = "fail_if_true")]

--- a/crates/rs1090/src/decode/bds/bds19.rs
+++ b/crates/rs1090/src/decode/bds/bds19.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Mode S Specific Services GICB Capability Report Part 2 (BDS 1,9)
@@ -24,7 +24,9 @@ use serde::Serialize;
  * Reference: ICAO Doc 9871 Table A-2-25, §3.1.2.6.10.2
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "19")]
 pub struct GICBCapabilityReportPart2 {
     #[deku(bits = "1", map = "fail_if_true")]

--- a/crates/rs1090/src/decode/bds/bds20.rs
+++ b/crates/rs1090/src/decode/bds/bds20.rs
@@ -1,6 +1,6 @@
 use super::bds08;
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Aircraft Identification (BDS 2,0)
@@ -48,7 +48,9 @@ use serde::Serialize;
  * Additional implementation guidelines: ICAO Doc 9871 §D.2.4.3
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "20")]
 pub struct AircraftIdentification {
     /// BDS Code (bits 1-8): Per ICAO Doc 9871 Table A-2-32  

--- a/crates/rs1090/src/decode/bds/bds21.rs
+++ b/crates/rs1090/src/decode/bds/bds21.rs
@@ -1,6 +1,6 @@
 use deku::prelude::*;
 use regex::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
 /**
@@ -57,7 +57,9 @@ use tracing::{debug, trace};
  * Reference: ICAO Doc 9871 Table A-2-33, Annex 10 Vol IV Table 3-7
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "21")]
 pub struct AircraftAndAirlineRegistrationMarkings {
     #[deku(bits = "1")]

--- a/crates/rs1090/src/decode/bds/bds30.rs
+++ b/crates/rs1090/src/decode/bds/bds30.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::decode::{AC13Field, ICAO};
 
@@ -66,7 +66,7 @@ use crate::decode::{AC13Field, ICAO};
  * Additional details: RTCA DO-185B, EUROCAE ED-143
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[serde(tag = "bds", rename = "30")]
 pub struct ACASResolutionAdvisory {
     #[deku(bits = "8", map = "fail_if_not30")]
@@ -197,7 +197,7 @@ pub struct ACASResolutionAdvisory {
     pub threat_type: ThreatType,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(id_type = "u8", bits = "2")]
 #[serde(untagged)]
 pub enum ThreatType {
@@ -222,7 +222,7 @@ pub enum ThreatType {
     },
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct ThreadAddress {
     /// Threat identity data (icao24).
     pub threat_identity: ICAO,
@@ -232,7 +232,7 @@ pub struct ThreadAddress {
     pub zeros: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct ThreatOrientation {
     /// Altitude code on 13 bits
     #[serde(rename = "threat_altitude")]

--- a/crates/rs1090/src/decode/bds/bds40.rs
+++ b/crates/rs1090/src/decode/bds/bds40.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Selected Vertical Intention (BDS 4,0)
@@ -67,7 +67,7 @@ use serde::Serialize;
  * from altitude control panel, FMS, or current altitude depending on flight mode."
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[serde(tag = "bds", rename = "40")]
 pub struct SelectedVerticalIntention {
     #[deku(reader = "read_selected(deku::reader)")]
@@ -163,7 +163,7 @@ pub struct SelectedVerticalIntention {
     pub target_altitude_source: TargetSource,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(id_type = "u8", bits = "2")]
 pub enum TargetSource {
     #[deku(id = "0")]

--- a/crates/rs1090/src/decode/bds/bds44.rs
+++ b/crates/rs1090/src/decode/bds/bds44.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Meteorological Routine Air Report (BDS 4,4)
@@ -69,7 +69,7 @@ use serde::Serialize;
  * Note: Two's complement coding used for all signed fields (§A.2.2.2)
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[serde(tag = "bds", rename = "44")]
 pub struct MeteorologicalRoutineAirReport {
     /// Figure of Merit / Source (bits 1-4): Per ICAO Doc 9871 Table A-2-68  
@@ -122,7 +122,7 @@ pub struct MeteorologicalRoutineAirReport {
     pub humidity: Option<f64>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum FigureOfMerit {
     /// Invalid
     Invalid,
@@ -137,7 +137,7 @@ pub enum FigureOfMerit {
     Reserved(u8),
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Turbulence {
     Nil,
     Light,

--- a/crates/rs1090/src/decode/bds/bds45.rs
+++ b/crates/rs1090/src/decode/bds/bds45.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 /**
@@ -71,7 +71,9 @@ use tracing::trace;
  * Note: Two's complement coding used for all signed fields (§A.2.2.2)
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone, Default,
+)]
 #[serde(tag = "bds", rename = "45")]
 pub struct MeteorologicalHazardReport {
     #[deku(reader = "read_level(deku::reader)")]
@@ -128,8 +130,9 @@ pub struct MeteorologicalHazardReport {
     pub reserved: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 pub enum Level {
+    #[default]
     Nil,
     Light,
     Moderate,

--- a/crates/rs1090/src/decode/bds/bds50.rs
+++ b/crates/rs1090/src/decode/bds/bds50.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Track and Turn Report (BDS 5,0)
@@ -72,7 +72,7 @@ use serde::Serialize;
  *
  * Note: Two's complement coding used for all signed fields (§A.2.2.2)
  */
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[serde(tag = "bds", rename = "50")]
 pub struct TrackAndTurnReport {
     /// Roll Angle (bits 1-11): Per ICAO Doc 9871 Table A-2-80  

--- a/crates/rs1090/src/decode/bds/bds60.rs
+++ b/crates/rs1090/src/decode/bds/bds60.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /**
  * ## Heading and Speed Report (BDS 6,0)
@@ -89,7 +89,7 @@ use serde::Serialize;
  * Note: Two's complement coding used for all signed fields (§A.2.2.2)
  * Additional implementation guidelines in ICAO Doc 9871 §D.2.4.6
  */
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[serde(tag = "bds", rename = "60")]
 pub struct HeadingAndSpeedReport {
     /// Magnetic Heading (bits 1-12): Per ICAO Doc 9871 Table A-2-96  

--- a/crates/rs1090/src/decode/bds/bds61.rs
+++ b/crates/rs1090/src/decode/bds/bds61.rs
@@ -1,6 +1,6 @@
 use crate::decode::IdentityCode;
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -61,7 +61,7 @@ use std::fmt;
  *
  * Reference: ICAO Doc 9871 Tables B-2-97a and B-2-97b
  */
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct AircraftStatus {
     /// Subtype (bits 6-8): Per ICAO Doc 9871 Table B-2-97a
     /// Identifies message content type.
@@ -112,7 +112,7 @@ impl fmt::Display for AircraftStatus {
 ///   - 1 = Emergency/priority status
 ///   - 2 = ACAS RA Broadcast
 ///   - 3-7 = Reserved
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(rename_all = "snake_case")]
 pub enum AircraftStatusType {
@@ -150,7 +150,7 @@ pub enum AircraftStatusType {
 ///   - 5 = Unlawful interference (Mode A code 7500)
 ///   - 6 = Downed aircraft
 ///   - 7 = Reserved
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(rename_all = "snake_case")]

--- a/crates/rs1090/src/decode/bds/bds62.rs
+++ b/crates/rs1090/src/decode/bds/bds62.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -104,7 +104,7 @@ use std::fmt;
  *
  * Reference: DO-260B §2.2.3.2.7.1, Figure 2-10
  */
-#[derive(Copy, Clone, Debug, Serialize, PartialEq, DekuRead)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, DekuRead)]
 pub struct TargetStateAndStatusInformation {
     /// Subtype (bits 6-7): Per DO-260B §2.2.3.2.7.1.2  
     /// Identifies format of Target State and Status Message.  
@@ -402,7 +402,7 @@ impl fmt::Display for TargetStateAndStatusInformation {
 
 /// Selected Altitude Source: Per DO-260B §2.2.3.2.7.1.3.2
 /// Indicates the source of the selected altitude data.
-#[derive(Copy, Clone, Debug, Serialize, PartialEq, DekuRead)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, DekuRead)]
 #[deku(id_type = "u8", bits = "1")]
 pub enum AltSource {
     /// Mode Control Panel / Flight Control Unit

--- a/crates/rs1090/src/decode/bds/bds65.rs
+++ b/crates/rs1090/src/decode/bds/bds65.rs
@@ -1,5 +1,5 @@
 use deku::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /**
@@ -90,7 +90,7 @@ use std::fmt;
  * Additional details: DO-260B §2.2.3.2.7.2
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(untagged)]
 pub enum AircraftOperationStatus {
@@ -117,14 +117,14 @@ impl fmt::Display for AircraftOperationStatus {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct OperationStatusAirborne {
     /// The capacity class
-    #[serde(skip)]
+    #[serde(skip, default = "serde_default_capability_class_airborne")]
     pub capability_class: CapabilityClassAirborne,
 
     /// The operational mode
-    #[serde(skip)]
+    #[serde(skip, default = "serde_default_operational_mode")]
     pub operational_mode: OperationalMode,
 
     #[deku(pad_bytes_before = "1")]
@@ -141,10 +141,10 @@ impl fmt::Display for OperationStatusAirborne {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct CapabilityClassAirborne {
     #[deku(bits = "2", assert_eq = "0")]
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     pub reserved0: u8,
 
     /// TCAS Resolution Advisory Active
@@ -158,7 +158,7 @@ pub struct CapabilityClassAirborne {
     pub cdti: bool,
 
     #[deku(bits = "2", assert_eq = "0")]
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     pub reserved1: u8,
 
     /// Air-Referenced Velocity Report Capability
@@ -180,6 +180,18 @@ pub struct CapabilityClassAirborne {
     /// - 2: Support for multiple TC reports
     /// - 3: Reserved
     pub tc: u8,
+}
+
+pub fn serde_default_capability_class_airborne() -> CapabilityClassAirborne {
+    CapabilityClassAirborne {
+        reserved0: 0,
+        acas: false,
+        cdti: false,
+        reserved1: 0,
+        arv: false,
+        ts: false,
+        tc: 0,
+    }
 }
 
 impl fmt::Display for CapabilityClassAirborne {
@@ -204,27 +216,27 @@ impl fmt::Display for CapabilityClassAirborne {
 }
 
 /// Version 2 support only
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct OperationStatusSurface {
     /// The capacity class
-    #[serde(skip)]
+    #[serde(skip, default = "serde_default_capability_class_surface")]
     pub capability_class: CapabilityClassSurface,
 
     /// The capacity class L/W codes
     #[deku(bits = "4")]
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     pub lw_codes: u8,
 
     /// The operational mode
-    #[serde(skip)]
+    #[serde(skip, default = "serde_default_operational_mode")]
     pub operational_mode: OperationalMode,
 
     /// The GPS antenna offset (2.2.3.2.7.2.4.7).
     /// Reference: <http://www.anteni.net/adsb/Doc/1090-WP30-18-DRAFT_DO-260B-V42.pdf>
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     pub gps_antenna_offset: u8,
 
-    #[serde(flatten)]
+    #[serde(flatten, default = "serde_default_adsb_version_surface")]
     pub version: ADSBVersionSurface,
 }
 
@@ -237,10 +249,10 @@ impl fmt::Display for OperationStatusSurface {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct CapabilityClassSurface {
     #[deku(bits = "2", assert_eq = "0")]
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     pub reserved0: u8,
 
     /// Position Offset Applied
@@ -274,6 +286,18 @@ pub struct CapabilityClassSurface {
     pub nic_c: u8,
 }
 
+pub fn serde_default_capability_class_surface() -> CapabilityClassSurface {
+    CapabilityClassSurface {
+        reserved0: 0,
+        poe: false,
+        es1090: false,
+        b2_low: false,
+        uat_in: false,
+        nac_v: 0,
+        nic_c: 0,
+    }
+}
+
 impl fmt::Display for CapabilityClassSurface {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "   NICc:               {}", self.nic_c)?;
@@ -282,10 +306,10 @@ impl fmt::Display for CapabilityClassSurface {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct OperationalMode {
     #[deku(bits = "2", assert_eq = "0")]
-    #[serde(skip)]
+    #[serde(skip, default = "u8::default")]
     reserved: u8,
 
     /// TCAS RA active
@@ -303,6 +327,17 @@ pub struct OperationalMode {
 
     #[deku(bits = "2")]
     system_design_assurance: u8,
+}
+
+pub fn serde_default_operational_mode() -> OperationalMode {
+    OperationalMode {
+        reserved: 0,
+        tcas_ra_active: false,
+        ident_switch_active: false,
+        reserved_recv_atc_service: false,
+        single_antenna_flag: false,
+        system_design_assurance: 0,
+    }
 }
 
 impl fmt::Display for OperationalMode {
@@ -333,7 +368,7 @@ impl fmt::Display for OperationalMode {
 /// (specification defined in RTCA document DO-260). Version 1 was introduced
 /// around 2008 (DO-260A), and version 2 around 2012 (DO-260B). Version 3 is
 /// currently being developed.
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(tag = "version")]
 pub enum ADSBVersionAirborne {
@@ -432,7 +467,7 @@ impl fmt::Display for ADSBVersionAirborne {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct AirborneV1 {
     #[deku(bits = "1")]
     #[serde(rename = "NICs")]
@@ -466,7 +501,7 @@ pub struct AirborneV1 {
     pub horizontal_reference_direction: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct AirborneV2 {
     #[deku(bits = "1")]
     #[serde(rename = "NICa")]
@@ -514,7 +549,7 @@ pub struct AirborneV2 {
 /// (specification defined in RTCA document DO-260).  
 /// Version 1 was introduced around 2008 (DO-260A), and version 2 around 2012 (DO-260B).
 /// Version 3 is currently being developed.
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(tag = "version")]
 pub enum ADSBVersionSurface {
@@ -533,6 +568,10 @@ pub enum ADSBVersionSurface {
     #[deku(id_pat = "3..=7")]
     #[serde(rename = "3to7")]
     Reserved { id: u8 },
+}
+
+pub fn serde_default_adsb_version_surface() -> ADSBVersionSurface {
+    ADSBVersionSurface::DOC9871AppendixA(Empty {})
 }
 
 impl ADSBVersionSurface {
@@ -603,7 +642,7 @@ impl fmt::Display for ADSBVersionSurface {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct SurfaceV1 {
     #[deku(bits = "1")]
     #[serde(rename = "NICs")]
@@ -632,7 +671,7 @@ pub struct SurfaceV1 {
     pub horizontal_reference_direction: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct SurfaceV2 {
     #[deku(bits = "1")]
     #[serde(rename = "NICa")]
@@ -668,16 +707,16 @@ pub struct SurfaceV2 {
     pub sil_supplement: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct Empty {}
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct EmptyU8 {
     pub id: u8,
     pub unused: u8,
 }
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
 pub struct ReservedStatus {
     pub data: [u8; 5],
 }

--- a/crates/rs1090/src/decode/commb.rs
+++ b/crates/rs1090/src/decode/commb.rs
@@ -16,7 +16,7 @@ use super::cpr::AircraftState;
 use super::AC13Field;
 use super::ICAO;
 use deku::{ctx::Order, prelude::*};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 use tracing::debug;
@@ -29,7 +29,7 @@ use tracing::debug;
  * and the last two codes (4,4, 4,5) report meteorological information.
  */
 
-#[derive(Debug, PartialEq, Serialize, Clone, Default)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 pub struct DF20DataSelector {
     #[serde(skip)]
     /// Set to true if all zeros, then there is no need to parse
@@ -121,7 +121,7 @@ impl DF20DataSelector {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone, Default)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 pub struct DF21DataSelector {
     #[serde(skip)]
     /// Set to true if all zeros, then there is no need to parse

--- a/crates/rs1090/src/decode/cpr.rs
+++ b/crates/rs1090/src/decode/cpr.rs
@@ -125,7 +125,9 @@ pub fn update_global_reference(
 }
 
 /// A flag to qualify a CPR position as odd or even
-#[derive(Debug, PartialEq, Eq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "1")]
 #[serde(rename_all = "snake_case")]

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -36,7 +36,7 @@ use tracing::debug;
  * | 24       | [`DF::CommDExtended`]               | 3.1.2.7.3   |
  */
 
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(id_type = "u8", bits = "5", ctx = "crc: u32")]
 #[serde(tag = "df")]
 pub enum DF {
@@ -46,31 +46,31 @@ pub enum DF {
     ShortAirAirSurveillance {
         /// Vertical status
         #[deku(bits = "1")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         vs: u8,
         /// CC:
         #[deku(bits = "1")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         cc: u8,
         /// unused
         #[deku(bits = "1")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         unused: u8,
         /// Sensitivity level, ACAS
         #[deku(bits = "3")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         sl: u8,
         /// Spare
         #[deku(bits = "2")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         unused1: u8,
         /// Reply information
         #[deku(bits = "4")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         ri: u8,
         /// unused
         #[deku(bits = "2")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         unused2: u8,
         /// Altitude code on 13 bits
         #[serde(rename = "altitude")]
@@ -135,7 +135,7 @@ pub enum DF {
         #[serde(rename = "icao24")]
         icao: ICAO,
         /// Parity/Interrogator identifier
-        #[serde(skip)]
+        #[serde(skip, default = "serde_default_icao_empty")]
         p_icao: ICAO,
     },
 
@@ -147,13 +147,13 @@ pub enum DF {
         /// Vertical Status (airborne: 0, onground: 1)
         vs: u8,
         #[deku(bits = "2")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         reserved1: u8,
         #[deku(bits = "3")]
         /// Sensitivity Level (inoperative: 0)
         sl: u8,
         #[deku(bits = "2")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         reserved2: u8,
         #[deku(bits = "4")]
         /// Reply information
@@ -164,14 +164,14 @@ pub enum DF {
         /// - 0111: ACAS with vertical and horizontal resolution capability
         ri: u8,
         #[deku(bits = "2")]
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         reserved3: u8,
         /// Altitude code on 13 bits
         #[serde(rename = "altitude")]
         ac: AC13Field,
         /// Message, ACAS (56 bits, a BDS of a type requested in UF=0)
         #[deku(count = "7")]
-        #[serde(skip)]
+        #[serde(skip, default = "Vec::new")]
         mv: Vec<u8>,
         /// Address/Parity
         #[serde(rename = "icao24")]
@@ -195,7 +195,7 @@ pub enum DF {
         #[serde(flatten)]
         cf: ControlField,
         /// Parity/interrogator identifier
-        #[serde(skip)]
+        #[serde(skip, default = "serde_default_icao_empty")]
         pi: ICAO,
     },
 
@@ -261,7 +261,7 @@ pub enum DF {
     /// 24: Comm-D Extended, Downlink Format 24 (3.1.2.7.3)
     #[deku(id_pat = "24..=31")]
     CommDExtended {
-        #[serde(skip)]
+        #[serde(skip, default = "u8::default")]
         id: u8,
         /// Reserved
         #[deku(bits = "1")]
@@ -280,14 +280,18 @@ pub enum DF {
     },
 }
 
+pub fn serde_default_icao_empty() -> ICAO {
+    ICAO(0)
+}
+
 /// The entry point to Mode S and ADS-B decoding
 ///
 /// Use as `Message::try_from()` in mostly all applications
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Message {
     /// Calculated from all bits, should be 0 for ADS-B (raises a DekuError),
     /// icao24 otherwise
-    #[serde(skip)]
+    #[serde(skip, default = "u32::default")]
     pub crc: u32,
 
     /// The Downlink Format encoded in 5 bits
@@ -522,7 +526,7 @@ pub fn serialize_config(decode_time: bool) {
         .expect("configuration can only happen once");
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct TimedMessage {
     /// The timestamp (in s) of the first time the message was received
     pub timestamp: f64,
@@ -606,6 +610,17 @@ impl Serialize for IcaoParity {
     {
         let icao = format!("{:06x}", &self.0);
         serializer.serialize_str(&icao)
+    }
+}
+
+impl<'de> Deserialize<'de> for IcaoParity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        <IcaoParity as core::str::FromStr>::from_str(&s)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -715,6 +730,18 @@ impl Serialize for IdentityCode {
     }
 }
 
+impl<'de> Deserialize<'de> for IdentityCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let num =
+            u16::from_str_radix(&s, 16).map_err(serde::de::Error::custom)?;
+        Ok(Self(num))
+    }
+}
+
 /// 13-bit encoded altitude field (AC field) per ICAO Annex 10 Vol IV §3.1.2.6.5.4
 ///
 /// # Encoding Modes
@@ -759,7 +786,9 @@ impl Serialize for IdentityCode {
 ///
 /// - ICAO Annex 10 Volume IV §3.1.2.6.5.4 (AC altitude code)
 /// - DO-260B §2.2.5.1.5 (all-zeros = not available)
-#[derive(Debug, PartialEq, Eq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone,
+)]
 pub struct AC13Field(
     #[deku(reader = "Self::read(deku::reader)")] pub Option<i32>,
 );
@@ -829,13 +858,16 @@ impl AC13Field {
 }
 
 /// Transponder level and additional information (3.1.2.5.2.2.1)
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "3")]
 #[allow(non_camel_case_types)]
 pub enum Capability {
     /// Level 1 transponder (surveillance only), and either airborne or on the ground
     #[serde(rename = "level1")]
+    #[default]
     AG_LEVEL1 = 0x00,
     #[deku(id_pat = "0x01..=0x03")]
     AG_RESERVED,
@@ -872,11 +904,14 @@ impl fmt::Display for Capability {
 }
 
 /// Airborne or Ground and SPI (used in DF=4, 5, 20 or 21)
-#[derive(Debug, PartialEq, Serialize, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(rename_all = "snake_case")]
 pub enum FlightStatus {
+    #[default]
     NoAlertNoSpiAirborne = 0b000,
     NoAlertNoSpiOnGround = 0b001,
     AlertNoSpiAirborne = 0b010,
@@ -906,10 +941,13 @@ impl fmt::Display for FlightStatus {
 }
 
 /// The downlink request (used in DF=4, 5, 20 or 21)
-#[derive(Debug, PartialEq, Eq, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "5")]
 pub enum DownlinkRequest {
+    #[default]
     None = 0b00000,
     RequestSendCommB = 0b00001,
     CommBBroadcastMsg1 = 0b00100,
@@ -919,18 +957,22 @@ pub enum DownlinkRequest {
 }
 
 /// The utility message (used in DF=4, 5, 20 or 21)
-#[derive(Debug, PartialEq, Eq, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 pub struct UtilityMessage {
     #[deku(bits = "4")]
     pub iis: u8,
     pub ids: UtilityMessageType,
 }
-
 /// The utility message type (used in DF=4, 5, 20 or 21)
-#[derive(Debug, PartialEq, Eq, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "2")]
 pub enum UtilityMessageType {
+    #[default]
     NoInformation = 0b00,
     CommB = 0b01,
     CommC = 0b10,
@@ -938,7 +980,7 @@ pub enum UtilityMessageType {
 }
 
 /// The control field in TIS-B messages (DF=18)
-#[derive(Debug, PartialEq, Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 pub struct ControlField {
     #[serde(rename = "tisb")]
     pub field_type: ControlFieldType,
@@ -957,7 +999,7 @@ impl fmt::Display for ControlField {
 }
 
 /// The control field type in TIS-B messages (DF=18)
-#[derive(Debug, PartialEq, serde::Serialize, DekuRead, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[allow(non_camel_case_types)]
 pub enum ControlFieldType {
@@ -1011,10 +1053,13 @@ impl fmt::Display for ControlFieldType {
 }
 
 /// Uplink / Downlink (DF=24)
-#[derive(Debug, PartialEq, Eq, DekuRead, Copy, Clone)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, DekuRead, Copy, Clone, Default,
+)]
 #[repr(u8)]
 #[deku(id_type = "u8", bits = "1")]
 pub enum KE {
+    #[default]
     DownlinkELMTx = 0,
     UplinkELMAck = 1,
 }


### PR DESCRIPTION
This allows `tangram_jet1090` to decode messages sent over Redis without duplicating struct definitions, similar in spirit to https://github.com/xoolive/ship162/commit/f585aeabbf5d513ea53fe5432b693b18e1522b12.

For deserialising fields marked with `#[serde(skip)]`, we `impl Default` with garbage values.