### PR TITLE
BDS inference improvement based on ASTERIX ground truth

### DIFF
--- a/crates/decode1090/readme.md
+++ b/crates/decode1090/readme.md
@@ -46,3 +46,10 @@ See `--help` for more information.
     "geo_minus_baro": -175
   }
   ```
+
+- Decode files. The `file` subcommand accepts JSONL and Beast CSV inputs directly, including compressed `.gz` and `.7z` files such as `.jsonl.7z` and `.csv.7z`.
+
+  ```sh
+  decode1090 file flight.jsonl.7z --reference LFBO --output decoded.jsonl
+  decode1090 file raw_beast.csv.7z --reference LFPO --output decoded.jsonl
+  ```

--- a/crates/decode1090/src/bds.rs
+++ b/crates/decode1090/src/bds.rs
@@ -59,7 +59,7 @@ pub fn process_bds_decode(
         }
     } else {
         // Inference mode: try all BDS codes
-        let inferred = infer_bds(&payload);
+        let inferred = infer_bds(&payload, None);
         let mut decoded_map = serde_json::json!({});
 
         for decoded in inferred.iter() {

--- a/crates/decode1090/src/cat48.rs
+++ b/crates/decode1090/src/cat48.rs
@@ -4,6 +4,7 @@ use deku::DekuContainerRead;
 use glob::glob;
 use rayon::prelude::*;
 use rs1090::decode::cat48::Cat48Record;
+use rs1090::decode::cpr::Position;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -81,6 +82,7 @@ fn parse_asterix_data(data: &[u8]) -> (Vec<Cat48Record>, usize) {
 }
 
 /// Process ASTERIX CAT48 files and output JSON with optional filtering.
+#[allow(clippy::too_many_arguments)]
 pub async fn process_cat48(
     inputs: Vec<String>,
     output: Option<String>,
@@ -89,6 +91,7 @@ pub async fn process_cat48(
     with_bds: bool,
     exclude_zero: bool,
     filter_bds: Option<String>,
+    radar: Option<Position>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Parse BDS filter codes
     let bds_filter: Option<Vec<u8>> = filter_bds.map(|s| {
@@ -237,6 +240,8 @@ pub async fn process_cat48(
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
     }
+
+    rs1090::decode::cat48::refine_inferred_bds(&mut all_records, radar);
 
     if array {
         // Output as single JSON array

--- a/crates/decode1090/src/file.rs
+++ b/crates/decode1090/src/file.rs
@@ -169,9 +169,11 @@ async fn process_entries(
             _ => {}
         }
 
-        // Sanitize Comm-B messages
+        // Sanitize Comm-B messages and record surviving BDS registers
+        // for use as evidence in subsequent GICB bitmap validation.
         MessageProcessor::new(message, aircraft)
             .sanitize_commb()
+            .record_observed_bds()
             .finish();
 
         let json = match serde_json::to_string(&msg) {

--- a/crates/decode1090/src/main.rs
+++ b/crates/decode1090/src/main.rs
@@ -178,7 +178,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         serde_json::to_string(&message).unwrap()
                     } else {
                         // BDS inference fallback
-                        let inferred = infer_bds(&bytes);
+                        let inferred = infer_bds(&bytes, None);
                         let mut decoded_map = serde_json::json!({});
                         for decoded in inferred.iter() {
                             let bds_code = bds_code_from_decoded(decoded);

--- a/crates/decode1090/src/main.rs
+++ b/crates/decode1090/src/main.rs
@@ -66,6 +66,10 @@ enum Commands {
         /// Comma-separated hex codes, e.g. "44,45" or "40,50,60"
         #[arg(long)]
         filter_bds: Option<String>,
+
+        /// Radar position used to cross-check locally decoded CPR candidates
+        #[arg(long)]
+        radar: Option<Position>,
     },
     /// Decode BDS payload (7 bytes)
     Bds {
@@ -120,6 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             with_bds,
             exclude_zero,
             filter_bds,
+            radar,
         }) => {
             return cat48::process_cat48(
                 inputs,
@@ -129,6 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 with_bds,
                 exclude_zero,
                 filter_bds,
+                radar,
             )
             .await;
         }

--- a/crates/decode1090/src/main.rs
+++ b/crates/decode1090/src/main.rs
@@ -83,9 +83,9 @@ enum Commands {
         #[arg(long, short)]
         bds: Option<String>,
     },
-    /// Decode Mode S messages from files (JSONL, CSV)
+    /// Decode Mode S messages from files (JSONL, CSV; plain, .gz, or .7z)
     File {
-        /// Input files (JSONL or CSV Beast format)
+        /// Input files (JSONL or CSV Beast format; .jsonl.7z and .csv.7z are supported directly)
         #[arg(required = true)]
         inputs: Vec<String>,
 

--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -702,10 +702,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        // Sanitize Comm-B messages before updating snapshot
+        // Sanitize Comm-B messages and record surviving BDS registers
+        // for use as evidence in subsequent GICB bitmap validation.
         if let Some(message) = &mut msg.message {
-            MessageProcessor::new(message, &aircraft)
+            MessageProcessor::new(message, &mut aircraft)
                 .sanitize_commb()
+                .record_observed_bds()
                 .finish();
         }
 

--- a/crates/rs1090-wasm/src/lib.rs
+++ b/crates/rs1090-wasm/src/lib.rs
@@ -269,7 +269,7 @@ pub fn decode_bds65(msg: &str) -> Result<JsValue, JsError> {
     let enum_id = &bytes[4] & 0b111;
     match (tc, enum_id) {
         (31, id) if id < 2 => {
-            match AircraftOperationStatus::from_bytes((&bytes[4..], 0)) {
+            match AircraftOperationStatus::from_bytes((&bytes[4..], 5)) {
                 Ok((_, msg)) => {
                     let map_result = serde_wasm_bindgen::to_value(&msg)?;
                     Ok(map_result)

--- a/crates/rs1090/src/decode/bds/bds05.rs
+++ b/crates/rs1090/src/decode/bds/bds05.rs
@@ -178,6 +178,15 @@ fn decode_ac12<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         // This supports negative altitudes for below-sea-level airports
         let n = ((num & 0x0fe0) >> 1) | (num & 0x000f);
         let altitude = i32::from(n) * 25 - 1000;
+        // hard-reject: no civil airliner operates above 50 000 ft; values
+        // higher than this almost certainly come from a phantom BDS 05
+        // candidate decoded from a different BDS payload.
+        #[cfg(feature = "bds-infer")]
+        if altitude > 50000 {
+            return Err(DekuError::Assertion(
+                format!("BDS 05 altitude {altitude} ft > 50 000 ft").into(),
+            ));
+        }
         Ok(Some(altitude))
     } else {
         // Gillham code encoding: 100 ft resolution, legacy Mode C
@@ -187,6 +196,12 @@ fn decode_ac12<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         n = decode_id13(n);
         if let Ok(n) = gray2alt(n) {
             let altitude = n * 100;
+            #[cfg(feature = "bds-infer")]
+            if altitude > 50000 {
+                return Err(DekuError::Assertion(
+                    format!("BDS 05 altitude {altitude} ft > 50 000 ft").into(),
+                ));
+            }
             Ok(Some(altitude))
         } else {
             Ok(None)

--- a/crates/rs1090/src/decode/bds/bds17.rs
+++ b/crates/rs1090/src/decode/bds/bds17.rs
@@ -122,18 +122,24 @@ pub struct CommonUsageGICBCapabilityReport {
     pub bds40: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Next waypoint identifier
+    /// Never set in civil-airliner ground truth
     pub bds41: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Next waypoint position
+    /// Never set in civil-airliner ground truth
     pub bds42: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Next waypoint information
+    /// Never set in civil-airliner ground truth
     pub bds43: bool,
 
     #[deku(bits = "1")]
@@ -147,8 +153,10 @@ pub struct CommonUsageGICBCapabilityReport {
     pub bds45: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// VHF channel report
+    /// Never set in civil-airliner ground truth
     pub bds48: bool,
 
     #[deku(bits = "1")]
@@ -172,18 +180,24 @@ pub struct CommonUsageGICBCapabilityReport {
     pub bds53: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Waypoint 1
+    /// Never set in civil-airliner ground truth
     pub bds54: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Waypoint 2
+    /// Never set in civil-airliner ground truth
     pub bds55: bool,
 
     #[deku(bits = "1")]
+    #[cfg_attr(feature = "bds-infer", deku(map = "fail_if_true"))]
     #[serde(skip_serializing_if = "is_false")]
     /// Waypoint 3
+    /// Never set in civil-airliner ground truth
     pub bds56: bool,
 
     #[deku(bits = "1")]
@@ -207,6 +221,17 @@ pub struct CommonUsageGICBCapabilityReport {
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+#[cfg(feature = "bds-infer")]
+fn fail_if_true(value: bool) -> Result<bool, DekuError> {
+    if value {
+        Err(DekuError::Assertion(
+            "BDS 1,7 dead capability bit is set".into(),
+        ))
+    } else {
+        Ok(value)
+    }
 }
 
 #[cfg(feature = "bds-infer")]

--- a/crates/rs1090/src/decode/bds/bds21.rs
+++ b/crates/rs1090/src/decode/bds/bds21.rs
@@ -1,8 +1,11 @@
 use deku::prelude::*;
-#[cfg(feature = "bds-infer")]
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
+
+#[cfg(feature = "bds-infer")]
+use crate::data::patterns::PATTERNS;
 
 /**
  * ## Aircraft and Airline Registration Markings (BDS 2,1)
@@ -139,21 +142,22 @@ pub fn aircraft_registration_read<
     debug!("Decoded registration: {}", encoded);
 
     if status {
-        #[cfg(not(feature = "bds-infer"))]
-        {
-            Ok(Some(encoded))
-        }
+        // hard-reject: real BDS 21 registrations contain at most 2 `#`
+        // placeholders (used by the 6-bit ICAO alphabet for non-alphanumeric
+        // positions). Strings with 3 or more `#` are almost always phantom
+        // decodes from a different BDS payload. The stricter
+        // country-prefix pattern check belongs to a separate filtering
+        // stage and is not enforced here.
         #[cfg(feature = "bds-infer")]
-        {
-            let re = Regex::new(r"^[A-Z0-9]+[\s#]?[A-Z0-9]+$").unwrap();
-            if re.is_match(&encoded) {
-                Ok(Some(encoded))
-            } else {
-                Err(DekuError::Assertion(
-                    format!("Invalid aircraft registration {encoded}").into(),
-                ))
-            }
+        if encoded.chars().filter(|&c| c == '#').count() > 2 {
+            return Err(DekuError::Assertion(
+                format!(
+                    "BDS 21 registration {encoded:?} has > 2 '#' placeholders"
+                )
+                .into(),
+            ));
         }
+        Ok(Some(encoded))
     } else if all_zeros {
         Ok(None)
     } else {
@@ -206,6 +210,94 @@ pub fn airline_registration_read<
     }
 }
 
+/// Validate a decoded BDS 2,1 registration against the country-prefix
+/// patterns derived from the aircraft's `icao24` address.
+///
+/// Returns `true` when the registration is plausible for the country
+/// inferred from the ICAO 24-bit address range, `false` when it should
+/// be rejected as a phantom candidate.
+///
+/// The check is organised into four buckets, tried in order:
+///
+/// 1. **Direct country-prefix match** — the registration matches the
+///    country's own pattern (e.g. `JA840J` for Japan `0x84xxxx`).
+/// 2. **Airline-prefix strip** — drop 2–3 leading characters (IATA airline
+///    code) and retry bucket 1 (e.g. `SQ9VDHA` → `9V-DHA` Singapore).
+/// 3. **Airline-suffix strip** — drop 2 trailing characters and retry
+///    bucket 1 (e.g. `B2487CA` → `B-2487` China).
+/// 4. **Flight-callsign shape** — matches `^[A-Z]{2,4}\d{2,5}[A-Z]{0,3}$`
+///    with length 5–7 and no `#` (e.g. `BRB1672`, `CIB1800`).
+///
+/// When no country pattern can be resolved for the `icao24` (unknown range
+/// or pattern-less entry), the function returns `true` to avoid false
+/// rejects on legitimate but uncommon registrations.
+#[cfg(feature = "bds-infer")]
+pub fn validate_registration(reg: &str, icao24: u32) -> bool {
+    // Bucket 4: flight-callsign shape — checked first because it is
+    // icao24-independent and very cheap.
+    static CALLSIGN_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^[A-Z]{2,4}\d{2,5}[A-Z]{0,3}$").unwrap());
+
+    // Resolve the country pattern for this ICAO address range.
+    let country_pattern: Option<String> = PATTERNS
+        .registers
+        .iter()
+        .find(|r| {
+            if let (Some(s), Some(e)) = (&r.start, &r.end) {
+                let start =
+                    u32::from_str_radix(&s[2..], 16).unwrap_or(u32::MAX);
+                let end = u32::from_str_radix(&e[2..], 16).unwrap_or(0);
+                icao24 >= start && icao24 <= end
+            } else {
+                false
+            }
+        })
+        .and_then(|r| r.pattern.clone());
+
+    // If no pattern is found for this range, accept unconditionally.
+    let Some(raw_pattern) = country_pattern else {
+        return true;
+    };
+
+    // Build a dash-stripped version of the pattern so it matches our
+    // canonical (dash-less) registrations.
+    let stripped_pattern = raw_pattern.replace('-', "");
+    let Ok(re) = Regex::new(&stripped_pattern) else {
+        return true; // malformed pattern → accept
+    };
+
+    // Bucket 1: direct country-prefix match.
+    if re.is_match(reg) {
+        return true;
+    }
+
+    // Buckets 2 & 3: airline-prefix/suffix strip.
+    for strip_len in [2usize, 3] {
+        // Prefix strip
+        if reg.len() > strip_len && re.is_match(&reg[strip_len..]) {
+            return true;
+        }
+        // Suffix strip (only length 2)
+        if strip_len == 2 && reg.len() > strip_len {
+            let end = reg.len() - strip_len;
+            if re.is_match(&reg[..end]) {
+                return true;
+            }
+        }
+    }
+
+    // Bucket 4: callsign shape (no `#`, length 5–7, IATA-like prefix).
+    if reg.len() >= 5
+        && reg.len() <= 7
+        && !reg.contains('#')
+        && CALLSIGN_RE.is_match(reg)
+    {
+        return true;
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +340,36 @@ mod tests {
         } else {
             unreachable!();
         }
+    }
+
+    #[cfg(feature = "bds-infer")]
+    #[test]
+    fn test_validate_registration() {
+        // Bucket 1: direct country match
+        // Japan: icao24 0x84xxxx, pattern "^JA"
+        assert!(validate_registration("JA824A", 0x843a1b));
+        // US: icao24 0xa0xxxx, pattern "^N"
+        assert!(validate_registration("N706CK", 0xa4a6fd));
+        // China: icao24 0x78xxxx, pattern "^B-"
+        assert!(validate_registration("B2487", 0x780123));
+        // France: icao24 0x38xxxx, pattern "^F-"
+        assert!(validate_registration("FGZHA", 0x3950ab));
+
+        // Bucket 2: airline-prefix strip (3 chars: SQ + 9V-DHA -> 9VDHA)
+        // Singapore: icao24 0x76xxxx, pattern "^9V-"
+        assert!(validate_registration("SQ9VDHA", 0x76c123));
+
+        // Bucket 3: airline-suffix strip (2 chars: B2487CA -> B2487)
+        assert!(validate_registration("B2487CA", 0x780123));
+
+        // Bucket 4: callsign shape
+        assert!(validate_registration("BRB1672", 0x843a1b));
+        assert!(validate_registration("CIB1800", 0x843a1b));
+
+        // Reject: clearly wrong country prefix for icao24 range
+        assert!(!validate_registration("XXXXXX", 0x843a1b)); // Japan range, non-JA
+                                                             // Reject: all-hash (would be caught by phi1 upstream, but validate_registration
+                                                             // also rejects non-matching strings)
+        assert!(!validate_registration("ZZZZZZ", 0x843a1b)); // Japan range, non-JA
     }
 }

--- a/crates/rs1090/src/decode/bds/bds21.rs
+++ b/crates/rs1090/src/decode/bds/bds21.rs
@@ -233,6 +233,14 @@ pub fn airline_registration_read<
 /// rejects on legitimate but uncommon registrations.
 #[cfg(feature = "bds-infer")]
 pub fn validate_registration(reg: &str, icao24: u32) -> bool {
+    // A leading placeholder is not a plausible registration prefix. Keeping
+    // such strings would be especially dangerous because BDS 2,1 is later
+    // treated as a high-confidence winner. Example false positive observed in
+    // Comm-B payloads: "#0NF" for a French address.
+    if reg.starts_with('#') {
+        return false;
+    }
+
     // Bucket 4: flight-callsign shape — checked first because it is
     // icao24-independent and very cheap.
     static CALLSIGN_RE: Lazy<Regex> =
@@ -266,21 +274,37 @@ pub fn validate_registration(reg: &str, icao24: u32) -> bool {
         return true; // malformed pattern → accept
     };
 
+    // Helper for country-prefix matches. Most country patterns are prefixes
+    // such as "^F-" (France), which become "^F" after dash stripping. In that
+    // case, matching the prefix alone is not enough: a registration must have
+    // at least one character after the country prefix. More specific patterns
+    // containing digit constraints (e.g. "^B-\\d{5}") are allowed to consume
+    // the whole candidate.
+    let country_match = |candidate: &str| -> bool {
+        let Some(m) = re.find(candidate) else {
+            return false;
+        };
+        if m.start() != 0 {
+            return false;
+        }
+        stripped_pattern.contains("\\d") || candidate.len() > m.end()
+    };
+
     // Bucket 1: direct country-prefix match.
-    if re.is_match(reg) {
+    if country_match(reg) {
         return true;
     }
 
     // Buckets 2 & 3: airline-prefix/suffix strip.
     for strip_len in [2usize, 3] {
         // Prefix strip
-        if reg.len() > strip_len && re.is_match(&reg[strip_len..]) {
+        if reg.len() > strip_len && country_match(&reg[strip_len..]) {
             return true;
         }
         // Suffix strip (only length 2)
         if strip_len == 2 && reg.len() > strip_len {
             let end = reg.len() - strip_len;
-            if re.is_match(&reg[..end]) {
+            if country_match(&reg[..end]) {
                 return true;
             }
         }
@@ -366,10 +390,17 @@ mod tests {
         assert!(validate_registration("BRB1672", 0x843a1b));
         assert!(validate_registration("CIB1800", 0x843a1b));
 
+        // Reject: leading placeholder and bare country prefix are too weak
+        // to be considered plausible registrations.
+        assert!(!validate_registration("#0NF", 0x39c422));
+        assert!(!validate_registration("F", 0x39c422));
+
         // Reject: clearly wrong country prefix for icao24 range
-        assert!(!validate_registration("XXXXXX", 0x843a1b)); // Japan range, non-JA
-                                                             // Reject: all-hash (would be caught by phi1 upstream, but validate_registration
-                                                             // also rejects non-matching strings)
+        // Japan range, non-JA
+        // Reject: all-hash (would be caught by the '#' count check upstream,
+        // but validate_registration also rejects non-matching strings)
+        assert!(!validate_registration("XXXXXX", 0x843a1b));
+
         assert!(!validate_registration("ZZZZZZ", 0x843a1b)); // Japan range, non-JA
     }
 }

--- a/crates/rs1090/src/decode/bds/bds40.rs
+++ b/crates/rs1090/src/decode/bds/bds40.rs
@@ -228,10 +228,12 @@ fn read_selected<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     let value = value * 16;
     // (encoded as a multiple of 16, but rounded to the closest 100 ft)
     let value = (value + 8) / 100 * 100;
+    // hard-reject: selected MCP/FMS altitudes
+    // above 50 000 ft are not operationally meaningful for civil airliners.
     #[cfg(feature = "bds-infer")]
-    if value > 45000 {
+    if value > 50000 {
         let msg = format!(
-            "Value for selected_fms or selected_mcp: {value} ft > 45000 ft"
+            "Value for selected_fms or selected_mcp: {value} ft > 50 000 ft"
         );
         return Err(DekuError::Assertion(msg.into()));
     }
@@ -284,7 +286,18 @@ fn read_qnh<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         }
     }
 
-    Ok(Some(value as f64 * 0.1 + 800.))
+    let baro = value as f64 * 0.1 + 800.;
+    // hard-reject: operational barometric
+    // settings stay within [800, 1200] mb. The encoding floor is 800 mb,
+    // so only the upper bound is reachable in practice.
+    #[cfg(feature = "bds-infer")]
+    if !(800. ..=1200.).contains(&baro) {
+        return Err(DekuError::Assertion(
+            format!("BDS 40 barometric setting {baro} mb outside [800, 1200]")
+                .into(),
+        ));
+    }
+    Ok(Some(baro))
 }
 
 #[cfg(test)]

--- a/crates/rs1090/src/decode/bds/bds44.rs
+++ b/crates/rs1090/src/decode/bds/bds44.rs
@@ -112,13 +112,15 @@ pub struct MeteorologicalRoutineAirReport {
     /// Turbulence (bits 47-49): Per ICAO Doc 9871 Table A-2-68  
     /// 2-bit turbulence level (Nil, Light, Moderate, Severe)  
     /// Definitions per PANS-ATM (Doc 4444).  
-    /// Returns None if status bit (bit 47) is 0.
+    /// Returns None if status bit (bit 47) is 0.  
+    /// Operationally never populated in civil-airliner transmissions.
     pub turbulence: Option<Turbulence>,
 
     #[deku(reader = "read_humidity(deku::reader)")]
     /// Humidity (bits 50-56): Per ICAO Doc 9871 Table A-2-68  
     /// 6-bit humidity percentage (LSB=100/64%, range [0, 100]%)  
-    /// Returns None if status bit (bit 50) is 0.
+    /// Returns None if status bit (bit 50) is 0.  
+    /// Operationally never populated in civil-airliner transmissions.
     pub humidity: Option<f64>,
 }
 
@@ -162,6 +164,17 @@ fn read_figure_of_merit<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         n @ 5..=15 => FigureOfMerit::Reserved(n),
         _ => unreachable!(),
     };
+    // hard-reject: the reserved FOM range (5–15) appears in 99.47 % of
+    // phantom candidates but only 0.01 % of real BDS 4,4 records.
+    // Invalid (0), DME/DME (3) and VOR/DME (4) are also rejected because
+    // they are never observed in operational civil-airliner transmissions.
+    #[cfg(feature = "bds-infer")]
+    if !matches!(fom, FigureOfMerit::INS | FigureOfMerit::GNSS) {
+        return Err(DekuError::Assertion(
+            format!("BDS 4,4 figure of merit {value} not in {{INS=1, GNSS=2}}")
+                .into(),
+        ));
+    }
     Ok(fom)
 }
 fn read_wind_speed<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
@@ -185,6 +198,9 @@ fn read_wind_speed<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
             return Ok(None);
         }
     }
+    // hard-reject: wind speed > 250 kt is
+    // outside operational envelopes (worst recorded jet-stream cores ~200 kt).
+    #[cfg(feature = "bds-infer")]
     if value > 250 {
         let msg = format!("Invalid wind speed {value} kts > 250 kts");
         return Err(DekuError::Assertion(msg.into()));
@@ -240,6 +256,10 @@ fn read_temperature<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     // Verified against 500 paired BDS 44/45 records: 100% match within 0.5°C.
     let temp = if temp < -80.0 { temp + 256.0 } else { temp };
 
+    // hard-reject: valid OAT at cruise is bounded by [-80, +60] °C.
+    // Always-on after the wrap-around fallback above (which itself is a
+    // bug-fix, not an inference choice).
+    #[cfg(feature = "bds-infer")]
     if !(-80. ..=60.).contains(&temp) {
         let msg = "Invalid temperature value {}°C outside [-80, 60]";
         return Err(DekuError::Assertion(msg.into()));
@@ -298,15 +318,25 @@ fn read_turbulence<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         }
     }
 
-    let value = match value {
-        0 => Some(Turbulence::Nil),
-        1 => Some(Turbulence::Light),
-        2 => Some(Turbulence::Moderate),
-        3 => Some(Turbulence::Severe),
-        _ => unreachable!(),
-    };
+    // hard-reject: turbulence is operationally never populated in civil-airliner
+    // BDS 4,4 transmissions; a non-null value almost certainly means this
+    // payload is a phantom candidate decoded from a different register.
+    #[cfg(feature = "bds-infer")]
+    return Err(DekuError::Assertion(
+        "BDS 4,4 turbulence field is non-null".into(),
+    ));
 
-    Ok(value)
+    #[cfg(not(feature = "bds-infer"))]
+    {
+        let value = match value {
+            0 => Some(Turbulence::Nil),
+            1 => Some(Turbulence::Light),
+            2 => Some(Turbulence::Moderate),
+            3 => Some(Turbulence::Severe),
+            _ => unreachable!(),
+        };
+        Ok(value)
+    }
 }
 
 fn read_humidity<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
@@ -329,6 +359,15 @@ fn read_humidity<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         }
     }
 
+    // hard-reject: humidity is operationally never populated in civil-airliner
+    // BDS 4,4 transmissions; a non-null value almost certainly means this
+    // payload is a phantom candidate decoded from a different register.
+    #[cfg(feature = "bds-infer")]
+    return Err(DekuError::Assertion(
+        "BDS 4,4 humidity field is non-null".into(),
+    ));
+
+    #[cfg(not(feature = "bds-infer"))]
     Ok(Some(value as f64 * 100. / 64.))
 }
 

--- a/crates/rs1090/src/decode/bds/bds45.rs
+++ b/crates/rs1090/src/decode/bds/bds45.rs
@@ -76,34 +76,31 @@ use tracing::trace;
 )]
 #[serde(tag = "bds", rename = "45")]
 pub struct MeteorologicalHazardReport {
-    #[deku(reader = "read_level(deku::reader)")]
+    #[deku(reader = "read_level_must_be_null(deku::reader)")]
     /// Turbulence (bits 1-3): Per ICAO Doc 9871 Table A-2-69  
-    /// Severity level (Nil, Light, Moderate, Severe) per PANS-ATM (Doc 4444)  
-    /// Returns None if status bit (bit 1) is 0.
+    /// Returns None if status bit is 0. Operationally never populated
+    /// by civil airliners; a non-null value almost certainly means this
+    /// payload is a phantom BDS 4,5 candidate decoded from another register.
     pub turbulence: Option<Level>,
 
-    #[deku(reader = "read_level(deku::reader)")]
+    #[deku(reader = "read_level_must_be_null(deku::reader)")]
     /// Wind Shear (bits 4-6): Per ICAO Doc 9871 Table A-2-69  
-    /// Severity level (Nil, Light, Moderate, Severe) per PANS-ATM (Doc 4444)  
-    /// Returns None if status bit (bit 4) is 0.
+    /// Returns None if status bit is 0. Operationally never populated.
     pub wind_shear: Option<Level>,
 
-    #[deku(reader = "read_level(deku::reader)")]
+    #[deku(reader = "read_level_must_be_null(deku::reader)")]
     /// Microburst (bits 7-9): Per ICAO Doc 9871 Table A-2-69  
-    /// Severity level (Nil, Light, Moderate, Severe) per PANS-ATM (Doc 4444)  
-    /// Returns None if status bit (bit 7) is 0.
+    /// Returns None if status bit is 0. Operationally never populated.
     pub microburst: Option<Level>,
 
-    #[deku(reader = "read_level(deku::reader)")]
+    #[deku(reader = "read_level_must_be_null(deku::reader)")]
     /// Icing (bits 10-12): Per ICAO Doc 9871 Table A-2-69  
-    /// Severity level (Nil, Light, Moderate, Severe) per PANS-ATM (Doc 4444)  
-    /// Returns None if status bit (bit 10) is 0.
+    /// Returns None if status bit is 0. Operationally never populated.
     pub icing: Option<Level>,
 
-    #[deku(reader = "read_level(deku::reader)")]
+    #[deku(reader = "read_level_must_be_null(deku::reader)")]
     /// Wake Vortex (bits 13-15): Per ICAO Doc 9871 Table A-2-69  
-    /// Severity level (Nil, Light, Moderate, Severe) per PANS-ATM (Doc 4444)  
-    /// Returns None if status bit (bit 13) is 0.
+    /// Returns None if status bit is 0. Operationally never populated.
     pub wake_vortex: Option<Level>,
 
     #[deku(reader = "read_temperature(deku::reader)")]
@@ -164,6 +161,23 @@ fn read_level<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     }
 }
 
+/// Like [`read_level`] but also rejects any non-null result under `bds-infer`.
+/// Operationally, civil airliners never populate BDS 4,5 hazard fields; a
+/// non-null value is a strong signal that this is a phantom candidate decoded
+/// from a different register.
+fn read_level_must_be_null<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
+    reader: &mut Reader<R>,
+) -> Result<Option<Level>, DekuError> {
+    let level = read_level(reader)?;
+    #[cfg(feature = "bds-infer")]
+    if level.is_some() {
+        return Err(DekuError::Assertion(
+            "BDS 4,5 hazard field is non-null".into(),
+        ));
+    }
+    Ok(level)
+}
+
 fn read_temperature<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     reader: &mut Reader<R>,
 ) -> Result<Option<f64>, DekuError> {
@@ -192,16 +206,33 @@ fn read_temperature<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     );
 
     let msg = "Invalid temperature value {}°C outside [-80, 60]";
-    match (status, value, temperature) {
-        (true, _, temperature) if (-80. ..=60.).contains(&temperature) => {
-            Ok(Some(temperature))
+    // hard-reject: valid OAT bounded by [-80, +60] °C.
+    #[cfg(feature = "bds-infer")]
+    {
+        match (status, value, temperature) {
+            (true, _, temperature) if (-80. ..=60.).contains(&temperature) => {
+                Ok(Some(temperature))
+            }
+            (true, _, _) => Err(DekuError::Assertion(msg.into())),
+            //(false, _) => Ok(None),
+            // In practice, I see quite some pressure fields with invalid status but non zero values
+            (false, 0, _) => Ok(None),
+            (false, _, _) => {
+                Err(DekuError::Assertion("Invalid temperature value".into()))
+            }
         }
-        (true, _, _) => Err(DekuError::Assertion(msg.into())),
-        //(false, _) => Ok(None),
-        // In practice, I see quite some pressure fields with invalid status but non zero values
-        (false, 0, _) => Ok(None),
-        (false, _, _) => {
-            Err(DekuError::Assertion("Invalid temperature value".into()))
+    }
+
+    // Without `bds-infer`, only the status / sign-bit structural checks remain.
+    #[cfg(not(feature = "bds-infer"))]
+    {
+        let _ = msg;
+        match (status, value) {
+            (true, _) => Ok(Some(temperature)),
+            (false, 0) => Ok(None),
+            (false, _) => {
+                Err(DekuError::Assertion("Invalid temperature value".into()))
+            }
         }
     }
 }

--- a/crates/rs1090/src/decode/bds/bds50.rs
+++ b/crates/rs1090/src/decode/bds/bds50.rs
@@ -138,8 +138,7 @@ pub struct TrackAndTurnReport {
     ///   - Special value: 0b111111111 = data not available
     ///
     /// Returns None if status bit is 0 or value = 0b111111111.
-    /// Implementation validates that sign agrees with roll_angle (left roll = left turn).
-    #[deku(reader = "read_rate(deku::reader, *roll_angle)")]
+    #[deku(reader = "read_rate(deku::reader)")]
     pub track_rate: Option<f64>,
 
     /// True Airspeed (bits 46-56): Per ICAO Doc 9871 Table A-2-80  
@@ -153,9 +152,8 @@ pub struct TrackAndTurnReport {
     ///   - Range: [0, 2046] kt
     ///
     /// Returns None if status bit is 0.
-    /// Implementation validates TAS ∈ [80, 500] kt and |GS - TAS| < 200 kt.
     /// Note: IAS (Indicated Airspeed) is available in BDS 6,0.
-    #[deku(reader = "read_tas(deku::reader, *groundspeed)")]
+    #[deku(reader = "read_tas(deku::reader)")]
     #[serde(rename = "TAS")]
     pub true_airspeed: Option<u16>,
 }
@@ -191,9 +189,13 @@ fn read_roll<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     } else {
         value as f64 * 45. / 256.
     };
-    if roll.abs() > 50. {
+    // hard-reject: |roll| > 45° is outside the civil-airliner envelope
+    // (typical bank limit is 30°, hard limit around 35–67° depending on
+    // aircraft / configuration).
+    #[cfg(feature = "bds-infer")]
+    if roll.abs() > 45. {
         return Err(DekuError::Assertion(
-            format!("Roll angle: abs({roll}) > 50").into(),
+            format!("Roll angle: abs({roll}) > 45").into(),
         ));
     }
     Ok(Some(roll))
@@ -261,10 +263,11 @@ fn read_groundspeed<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     }
 
     let gs = value * 2;
+    // hard-reject: groundspeed > 700 kt is outside the civil-airliner envelope.
     #[cfg(feature = "bds-infer")]
-    if gs > 600 {
+    if gs > 700 {
         return Err(DekuError::Assertion(
-            format!("Groundspeed value: {gs} > 600").into(),
+            format!("Groundspeed value: {gs} > 700").into(),
         ));
     }
     Ok(Some(gs))
@@ -272,7 +275,6 @@ fn read_groundspeed<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 
 fn read_rate<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     reader: &mut Reader<R>,
-    roll: Option<f64>,
 ) -> Result<Option<f64>, DekuError> {
     let status = bool::from_reader_with_ctx(
         reader,
@@ -308,27 +310,11 @@ fn read_rate<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     };
     let rate = value as f64 * 8. / 256.;
 
-    if let Some(roll) = roll {
-        #[cfg(feature = "bds-infer")]
-        if roll * rate < 0. {
-            // signs must agree: left wing down = turn left
-            return Err(DekuError::Assertion(
-                format!(
-                    "Roll angle {roll} and track rate {rate} signs do not agree."
-                )
-                .into(),
-            ));
-        }
-        #[cfg(not(feature = "bds-infer"))]
-        let _ = roll;
-    }
-
     Ok(Some(rate))
 }
 
 fn read_tas<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     reader: &mut Reader<R>,
-    gs: Option<u16>,
 ) -> Result<Option<u16>, DekuError> {
     let status = bool::from_reader_with_ctx(
         reader,
@@ -351,16 +337,14 @@ fn read_tas<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 
     let tas = value * 2;
 
+    // hard-reject: TAS > 600 kt is outside the civil-airliner envelope.
     #[cfg(feature = "bds-infer")]
-    if let Some(gs) = gs {
-        if !(80..=500).contains(&tas) | ((gs as i16 - tas as i16).abs() > 200) {
-            return Err(DekuError::Assertion(format!(
-                "TAS = {tas} must be within [80, 500] and abs(GS - TAS) = {gs} < 200"
-            ).into()));
-        }
+    if tas > 600 {
+        return Err(DekuError::Assertion(
+            format!("TAS value: {tas} > 600").into(),
+        ));
     }
-    #[cfg(not(feature = "bds-infer"))]
-    let _ = gs;
+
     Ok(Some(tas))
 }
 

--- a/crates/rs1090/src/decode/bds/bds50.rs
+++ b/crates/rs1090/src/decode/bds/bds50.rs
@@ -337,11 +337,14 @@ fn read_tas<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 
     let tas = value * 2;
 
-    // hard-reject: TAS > 600 kt is outside the civil-airliner envelope.
+    // hard-reject: a valid TAS below 80 kt is below the conservative
+    // airborne envelope for aircraft transmitting this report; unavailable
+    // TAS must be encoded with the status bit cleared and decoded as None.
+    // TAS > 600 kt is outside the civil-airliner envelope.
     #[cfg(feature = "bds-infer")]
-    if tas > 600 {
+    if !(80..=600).contains(&tas) {
         return Err(DekuError::Assertion(
-            format!("TAS value: {tas} > 600").into(),
+            format!("TAS value: {tas} outside [80, 600]").into(),
         ));
     }
 

--- a/crates/rs1090/src/decode/bds/bds60.rs
+++ b/crates/rs1090/src/decode/bds/bds60.rs
@@ -81,10 +81,6 @@ use serde::{Deserialize, Serialize};
  * Implementation Validation:
  * - IAS must be in range (0, 500] kt (operational validation)
  * - Mach must be in range (0, 1] (subsonic aircraft assumption)
- * - IAS and Mach cross-validation:
- *   * If IAS > 250 kt, then Mach must be ≥ 0.4 (250 kt ≈ Mach 0.45 at 10,000 ft)
- *   * If IAS < 150 kt, then Mach must be ≤ 0.5 (150 kt ≈ Mach 0.5 at FL400)
- * - Vertical rate/velocity abs value ≤ 6,000 ft/min (typical operational limit)
  *
  * Note: Two's complement coding used for all signed fields (§A.2.2.2)
  * Additional implementation guidelines in ICAO Doc 9871 §D.2.4.6
@@ -142,7 +138,7 @@ pub struct HeadingAndSpeedReport {
     ///   - Cross-validation with IAS:
     ///     * If IAS > 250 kt: Mach ≥ 0.4 (250 kt ≈ Mach 0.45 at 10,000 ft)
     ///     * If IAS < 150 kt: Mach ≤ 0.5 (150 kt ≈ Mach 0.5 at FL400)
-    #[deku(reader = "read_mach(deku::reader, *indicated_airspeed)")]
+    #[deku(reader = "read_mach(deku::reader)")]
     #[serde(rename = "Mach", skip_serializing_if = "Option::is_none")]
     pub mach_number: Option<f64>,
 
@@ -162,7 +158,7 @@ pub struct HeadingAndSpeedReport {
     /// Implementation validates abs(rate) ≤ 6,000 ft/min.  
     /// Source: Air Data System or Inertial Reference System/FMS.  
     /// Note: Usually unsteady and may suffer from barometric instrument inertia.
-    #[deku(reader = "read_vertical(deku::reader)")]
+    #[deku(reader = "read_vertical(deku::reader, false)")]
     #[serde(
         rename = "vrate_barometric",
         skip_serializing_if = "Option::is_none"
@@ -187,7 +183,7 @@ pub struct HeadingAndSpeedReport {
     /// Note: More filtered and smooth than barometric rate. When barometric
     /// altitude rate is integrated and smoothed with inertial data
     /// (baro-inertial), it shall be transmitted in this field.
-    #[deku(reader = "read_vertical(deku::reader)")]
+    #[deku(reader = "read_vertical(deku::reader, true)")]
     #[serde(
         rename = "vrate_inertial",
         skip_serializing_if = "Option::is_none"
@@ -256,11 +252,11 @@ fn read_ias<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         }
     }
 
+    // hard-reject: IAS > 500 kt is outside the civil-airliner envelope.
     #[cfg(feature = "bds-infer")]
-    if (value == 0) | (value > 500) {
+    if value > 500 {
         return Err(DekuError::Assertion(
-            format!("IAS value {value} is equal to 0 or greater than 500")
-                .into(),
+            format!("IAS value {value} > 500").into(),
         ));
     }
     Ok(Some(value))
@@ -268,7 +264,6 @@ fn read_ias<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 
 fn read_mach<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     reader: &mut Reader<R>,
-    ias: Option<u16>,
 ) -> Result<Option<f64>, DekuError> {
     let status = bool::from_reader_with_ctx(
         reader,
@@ -291,48 +286,19 @@ fn read_mach<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 
     let mach = value as f64 * 2.048 / 512.;
 
+    // hard-reject: Mach > 1 (no civil airliner is supersonic).
     #[cfg(feature = "bds-infer")]
-    if (mach == 0.) | (mach > 1.) {
+    if mach > 1. {
         return Err(DekuError::Assertion(
-            format!("Mach value {mach} equal to 0 or greater than 1 ").into(),
+            format!("Mach value {mach} > 1").into(),
         ));
-    }
-    if let Some(ias) = ias {
-        /*
-         * >>> pitot.aero.cas2mach(250, 10000)
-         * 0.45229071380275554
-         *
-         * Let's do this:
-         * 10000 ft has IAS max to 250, i.e. Mach 0.45
-         * forbid IAS > 250 and Mach < 0.5
-         */
-        #[cfg(feature = "bds-infer")]
-        if (ias > 250) & (mach < 0.4) {
-            return Err(DekuError::Assertion(
-                format!(
-                    "IAS: {ias} and Mach: {mach} (250kts is Mach 0.45 at 10,000 ft)"
-                )
-                .into(),
-            ));
-        }
-        // this one is easy IAS = 150 (close to take-off) at FL 400 is Mach 0.5
-        #[cfg(feature = "bds-infer")]
-        if (ias < 150) & (mach > 0.5) {
-            return Err(DekuError::Assertion(
-                format!(
-                    "IAS: {ias} and Mach: {mach} (150kts is Mach 0.5 at FL400)"
-                )
-                .into(),
-            ));
-        }
-        #[cfg(not(feature = "bds-infer"))]
-        let _ = ias;
     }
     Ok(Some(mach))
 }
 
 fn read_vertical<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
     reader: &mut Reader<R>,
+    check_range: bool,
 ) -> Result<Option<i16>, DekuError> {
     let status = bool::from_reader_with_ctx(
         reader,
@@ -367,13 +333,20 @@ fn read_vertical<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
         value as i16 * 32
     };
 
+    // hard-reject: only the *inertial* vertical velocity is range-checked
+    // (|vrate| ≤ 6 000 ft/min). The barometric altitude rate is left unbounded
+    // because it is known to be noisy and may legitimately exceed this envelope
+    // due to barometric instrument inertia, especially in turbulence or near
+    // pressure-pattern boundaries.
     #[cfg(feature = "bds-infer")]
-    if value.abs() > 6000 {
+    if check_range && value.abs() > 6000 {
         return Err(DekuError::Assertion(
             format!("Vertical rate absolute value {} > 6000", value.abs())
                 .into(),
         ));
     }
+    #[cfg(not(feature = "bds-infer"))]
+    let _ = check_range;
     Ok(Some(value))
 }
 

--- a/crates/rs1090/src/decode/bds/bds62.rs
+++ b/crates/rs1090/src/decode/bds/bds62.rs
@@ -227,7 +227,6 @@ pub struct TargetStateAndStatusInformation {
     ///   - 0 = barometric altitude not cross-checked with another source
     ///   - 1 = barometric altitude cross-checked with another pressure source
     #[deku(bits = "1")]
-    #[serde(skip)]
     pub nic_baro: bool,
 
     /// SIL (bits 45-46): Per DO-260B §2.2.3.2.7.1.3.10  

--- a/crates/rs1090/src/decode/bds/bds65.rs
+++ b/crates/rs1090/src/decode/bds/bds65.rs
@@ -1,4 +1,5 @@
 use deku::prelude::*;
+use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -369,7 +370,7 @@ impl fmt::Display for OperationalMode {
 /// (specification defined in RTCA document DO-260). Version 1 was introduced
 /// around 2008 (DO-260A), and version 2 around 2012 (DO-260B). Version 3 is
 /// currently being developed.
-#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(tag = "version")]
 pub enum ADSBVersionAirborne {
@@ -388,6 +389,49 @@ pub enum ADSBVersionAirborne {
     #[deku(id_pat = "3..=7")]
     #[serde(rename = "3to7")]
     Reserved { id: u8 },
+}
+
+impl Serialize for ADSBVersionAirborne {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::DOC9871AppendixA(_) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("version", &0u8)?;
+                map.end()
+            }
+            Self::DOC9871AppendixB(v1) => {
+                let mut map = serializer.serialize_map(Some(7))?;
+                map.serialize_entry("version", &1u8)?;
+                map.serialize_entry("NICs", &v1.nic_s)?;
+                map.serialize_entry("NACp", &v1.nac_p)?;
+                map.serialize_entry("BAQ", &v1.barometric_altitude_quality)?;
+                map.serialize_entry("SIL", &v1.sil)?;
+                map.serialize_entry("BAI", &v1.barometric_altitude_integrity)?;
+                map.serialize_entry("HRD", &v1.horizontal_reference_direction)?;
+                map.end()
+            }
+            Self::DOC9871AppendixC(v2) => {
+                let mut map = serializer.serialize_map(Some(8))?;
+                map.serialize_entry("version", &2u8)?;
+                map.serialize_entry("NICa", &v2.nic_a)?;
+                map.serialize_entry("NACp", &v2.nac_p)?;
+                map.serialize_entry("GVA", &v2.geometry_vertical_accuracy)?;
+                map.serialize_entry("SIL", &v2.sil)?;
+                map.serialize_entry("BAI", &v2.barometric_altitude_integrity)?;
+                map.serialize_entry("HRD", &v2.horizontal_reference_direction)?;
+                map.serialize_entry("SILs", &v2.sil_s)?;
+                map.end()
+            }
+            Self::Reserved { id } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("version", id)?;
+                map.end()
+            }
+        }
+    }
 }
 
 impl ADSBVersionAirborne {
@@ -550,7 +594,7 @@ pub struct AirborneV2 {
 /// (specification defined in RTCA document DO-260).  
 /// Version 1 was introduced around 2008 (DO-260A), and version 2 around 2012 (DO-260B).
 /// Version 3 is currently being developed.
-#[derive(Debug, PartialEq, Serialize, Deserialize, DekuRead, Copy, Clone)]
+#[derive(Debug, PartialEq, Deserialize, DekuRead, Copy, Clone)]
 #[deku(id_type = "u8", bits = "3")]
 #[serde(tag = "version")]
 pub enum ADSBVersionSurface {
@@ -573,6 +617,47 @@ pub enum ADSBVersionSurface {
 
 pub fn serde_default_adsb_version_surface() -> ADSBVersionSurface {
     ADSBVersionSurface::DOC9871AppendixA(Empty {})
+}
+
+impl Serialize for ADSBVersionSurface {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::DOC9871AppendixA(_) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("version", &0u8)?;
+                map.end()
+            }
+            Self::DOC9871AppendixB(v1) => {
+                let mut map = serializer.serialize_map(Some(6))?;
+                map.serialize_entry("version", &1u8)?;
+                map.serialize_entry("NICs", &v1.nic_s)?;
+                map.serialize_entry("NACp", &v1.nac_p)?;
+                map.serialize_entry("SIL", &v1.sil)?;
+                map.serialize_entry("TAH", &v1.track_angle_or_heading)?;
+                map.serialize_entry("HRD", &v1.horizontal_reference_direction)?;
+                map.end()
+            }
+            Self::DOC9871AppendixC(v2) => {
+                let mut map = serializer.serialize_map(Some(7))?;
+                map.serialize_entry("version", &2u8)?;
+                map.serialize_entry("NICa", &v2.nic_a)?;
+                map.serialize_entry("NACp", &v2.nac_p)?;
+                map.serialize_entry("SIL", &v2.sil)?;
+                map.serialize_entry("TAH", &v2.track_angle_or_heading)?;
+                map.serialize_entry("HRD", &v2.horizontal_reference_direction)?;
+                map.serialize_entry("SILs", &v2.sil_supplement)?;
+                map.end()
+            }
+            Self::Reserved { id } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("version", id)?;
+                map.end()
+            }
+        }
+    }
 }
 
 impl ADSBVersionSurface {
@@ -755,6 +840,9 @@ mod tests {
                 } else {
                     panic!("Expected version 2");
                 }
+
+                let json = serde_json::to_value(surface).unwrap();
+                assert_eq!(json["version"], 2);
 
                 // Test Display implementation
                 let display = format!("{}", surface.version);

--- a/crates/rs1090/src/decode/bds/density.rs
+++ b/crates/rs1090/src/decode/bds/density.rs
@@ -1,0 +1,221 @@
+//! Density-based scoring of decoded BDS candidates.
+//!
+//! For each candidate BDS code, a per-field log-density is computed under a
+//! fitted Gaussian or Laplace distribution, and the **mean** of those
+//! per-field log-densities is compared against [`DENSITY_THRESHOLD`]
+//! (default −3.0). When the mean falls below the threshold, the candidate
+//! is rejected.
+//!
+//! Distribution parameters are calibrated on a month of CAT 048 ground
+//! truth such that the p99 of legitimate scores ≈ −2.0 — high enough that
+//! cruise extremes, turning aircraft and high-wind situations still pass.
+//!
+//! Because the score is a *mean* across multiple decoded fields, it cannot
+//! live inside a per-field deku reader. It is applied **after** a
+//! successful decode in [`super::decode_bds`] / [`super::decode_payload`].
+//! Candidates whose decoded struct exposes no scored field are accepted
+//! unconditionally — there is no signal to score against.
+//!
+//! This module is only compiled when the `bds-infer` feature is enabled.
+
+use super::DecodedBds;
+
+/// Mean log-density rejection threshold (default: −3.0).
+pub const DENSITY_THRESHOLD: f64 = -3.0;
+
+/// Gaussian log-density (un-normalised; the constant `−ln(σ√2π)` is shared
+/// across candidates and would just shift the threshold, so it is omitted).
+#[inline]
+fn gauss(value: f64, mu: f64, sigma: f64) -> f64 {
+    let z = (value - mu) / sigma;
+    -0.5 * z * z
+}
+
+/// Laplace log-density (un-normalised; the constant `−ln(2b)` is omitted
+/// for the same reason as in [`gauss`]).
+#[inline]
+fn laplace(value: f64, median: f64, b: f64) -> f64 {
+    if b <= 0.0 {
+        return 0.0;
+    }
+    -(value - median).abs() / b
+}
+
+/// Accumulator helper: push `(log_density, 1)` only when `value` is `Some`.
+struct Acc {
+    total: f64,
+    count: u32,
+}
+
+impl Acc {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            total: 0.0,
+            count: 0,
+        }
+    }
+    #[inline]
+    fn add(&mut self, ld: f64) {
+        self.total += ld;
+        self.count += 1;
+    }
+    #[inline]
+    fn mean(&self) -> Option<f64> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self.total / f64::from(self.count))
+        }
+    }
+}
+
+/// Compute the mean log-density across the scored fields of a decoded BDS
+/// candidate.
+///
+/// Returns `None` when no scored field is present (the candidate is then
+/// accepted by [`passes`]).
+#[must_use]
+pub fn density_score(decoded: &DecodedBds) -> Option<f64> {
+    let mut acc = Acc::new();
+    match decoded {
+        DecodedBds::Bds05(p) => {
+            // altitude: gauss(26302, 10573)
+            if let Some(alt) = p.alt {
+                acc.add(gauss(f64::from(alt), 26302.0, 10573.0));
+            }
+        }
+        DecodedBds::Bds40(s) => {
+            // barometric_setting: laplace(1013.2, 5.4)
+            if let Some(v) = s.barometric_setting {
+                acc.add(laplace(v, 1013.2, 5.4));
+            }
+            // selected_mcp / selected_fms: gauss(24688, 10844)
+            if let Some(v) = s.selected_altitude_mcp {
+                acc.add(gauss(f64::from(v), 24688.0, 10844.0));
+            }
+            if let Some(v) = s.selected_altitude_fms {
+                acc.add(gauss(f64::from(v), 24688.0, 10844.0));
+            }
+        }
+        DecodedBds::Bds50(t) => {
+            // roll: laplace(0, 10)
+            if let Some(v) = t.roll_angle {
+                acc.add(laplace(v, 0.0, 10.0));
+            }
+            // track_rate: laplace(0, 0.70)
+            if let Some(v) = t.track_rate {
+                acc.add(laplace(v, 0.0, 0.70));
+            }
+            // TAS: gauss(413, 120)
+            if let Some(v) = t.true_airspeed {
+                acc.add(gauss(f64::from(v), 413.0, 120.0));
+            }
+            // groundspeed: gauss(418, 129)
+            if let Some(v) = t.groundspeed {
+                acc.add(gauss(f64::from(v), 418.0, 129.0));
+            }
+        }
+        DecodedBds::Bds60(h) => {
+            // IAS: gauss(272, 55)
+            if let Some(v) = h.indicated_airspeed {
+                acc.add(gauss(f64::from(v), 272.0, 55.0));
+            }
+            // Mach: gauss(0.69, 0.21)
+            if let Some(v) = h.mach_number {
+                acc.add(gauss(v, 0.69, 0.21));
+            }
+            // vrate_inertial: gauss(-298, 1669)
+            if let Some(v) = h.inertial_vertical_velocity {
+                acc.add(gauss(f64::from(v), -298.0, 1669.0));
+            }
+        }
+        DecodedBds::Bds44(m) => {
+            // temperature: laplace(-21.0, 9.90). Always present (non-Option).
+            acc.add(laplace(m.temperature, -21.0, 9.90));
+            // wind_speed: gauss(52, 29)
+            if let Some(v) = m.wind_speed {
+                acc.add(gauss(f64::from(v), 52.0, 29.0));
+            }
+            // pressure (hPa): laplace(393, 290)
+            if let Some(v) = m.pressure {
+                acc.add(laplace(f64::from(v), 393.0, 290.0));
+            }
+        }
+        DecodedBds::Bds45(m) => {
+            // static_temperature: gauss(-14.2, 16.4)
+            if let Some(v) = m.static_temperature {
+                acc.add(gauss(v, -14.2, 16.4));
+            }
+            // static_pressure (hPa): laplace(393, 290)
+            if let Some(v) = m.static_pressure {
+                acc.add(laplace(f64::from(v), 393.0, 290.0));
+            }
+        }
+        // No distributions are fitted for the remaining BDS codes
+        // (06, 08, 09, 10, 17, 18, 19, 20, 21, 30, 61, 62, 65). They are
+        // accepted unconditionally by the density rule (the decision is
+        // deferred to other heuristics or to the structural decoders).
+        _ => {}
+    }
+    acc.mean()
+}
+
+/// Decide whether the candidate passes the density rule alone.
+///
+/// Returns `true` when (a) the candidate has no scored field, or (b) the
+/// mean log-density is at or above [`DENSITY_THRESHOLD`].
+#[must_use]
+pub fn passes(decoded: &DecodedBds) -> bool {
+    match density_score(decoded) {
+        Some(score) => score >= DENSITY_THRESHOLD,
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cruise-typical BDS 50 (TAS 460, GS 470, roll −2°, track_rate 0)
+    /// scores well above the rejection threshold.
+    #[test]
+    fn cruise_bds50_passes() {
+        // Field-by-field hand-computed log-densities (un-normalised):
+        //   roll = −2°  → laplace(0, 10)   = −0.20
+        //   trk_rate=0  → laplace(0, 0.70) =  0.00
+        //   TAS  = 460  → gauss(413, 120)  = −0.0767
+        //   GS   = 470  → gauss(418, 129)  = −0.0813
+        // mean ≈ −0.090, well above −3.0.
+        let mut acc = Acc::new();
+        acc.add(laplace(-2.0, 0.0, 10.0));
+        acc.add(laplace(0.0, 0.0, 0.70));
+        acc.add(gauss(460.0, 413.0, 120.0));
+        acc.add(gauss(470.0, 418.0, 129.0));
+        let m = acc.mean().unwrap();
+        assert!(m > DENSITY_THRESHOLD, "cruise mean = {m}");
+    }
+
+    /// A BDS 60 with implausible-but-structurally-valid Mach (0.05) and
+    /// IAS (50 kt) drifts well into the rejection zone.
+    #[test]
+    fn slow_bds60_fails() {
+        // IAS  = 50   → gauss(272, 55)    ≈ −8.2
+        // Mach = 0.05 → gauss(0.69, 0.21) ≈ −2.25
+        // mean ≈ −5.2.
+        let mut acc = Acc::new();
+        acc.add(gauss(50.0, 272.0, 55.0));
+        acc.add(gauss(0.05, 0.69, 0.21));
+        let m = acc.mean().unwrap();
+        assert!(m < DENSITY_THRESHOLD, "slow mean = {m}");
+    }
+
+    /// Per-field log-density helpers behave as advertised at the centre.
+    #[test]
+    fn density_at_centre_is_zero() {
+        assert_eq!(gauss(1.0, 1.0, 2.0), 0.0);
+        assert_eq!(laplace(1013.2, 1013.2, 5.4), 0.0);
+        // Degenerate Laplace (b ≤ 0) returns 0 instead of dividing by zero.
+        assert_eq!(laplace(1.0, 0.0, 0.0), 0.0);
+    }
+}

--- a/crates/rs1090/src/decode/bds/mod.rs
+++ b/crates/rs1090/src/decode/bds/mod.rs
@@ -6,24 +6,41 @@
 //! code of a Comm-B reply must be guessed from the 56-bit MB payload alone.
 //! Two strategies are available, switched at compile time:
 //!
-//! * **Default (`bds-infer` feature on)** — full inference strategy. Each
-//!   candidate decoder enforces physical range checks (e.g. groundspeed
-//!   ≤ 600 kt, Mach ≤ 1, |TAS − GS| ≤ 200 kt), cross-field consistency
-//!   (roll vs. track-rate sign, IAS vs. Mach), strict capability-bit
-//!   constraints from ICAO Doc 9871 on BDS 17 / 18, and the BDS 21
-//!   registration regex. The candidate set in [`infer_bds`] also includes
-//!   BDS 06 / 08 / 09 / 61 / 62.
+//! * **Default (`bds-infer` feature on)** — full inference strategy.
+//!   In addition to the structural / status-bit checks of the minimal
+//!   strategy, the following families of validation rules are active:
 //!
-//! * **Minimal (`--no-default-features`)** — reproduces the IWAC 2026 paper
-//!   § 4.1 baseline. Only reserved bits, status-bit consistency and
-//!   spec-mandated value ranges are enforced; the relaxed capability bits
-//!   on BDS 17 / 18 are accepted; BDS 06 / 08 / 09 / 61 / 62 are excluded
-//!   from [`infer_bds`]. This is the configuration on top of which the
-//!   paper's φ → X → S → P → T scoring pipeline is layered.
+//!   - **Hard physical-limit rejection** in the per-field readers:
+//!     BDS 05 altitude ≤ 50 000 ft;
+//!     BDS 40 selected MCP / FMS altitude ≤ 50 000 ft and barometric setting
+//!     in [800, 1200] mb;
+//!     BDS 50 groundspeed ≤ 700 kt, TAS ≤ 600 kt, |roll| ≤ 45°;
+//!     BDS 60 IAS ≤ 500 kt, Mach ≤ 1, |vrate_inertial| ≤ 6 000 ft/min
+//!     (the *barometric* altitude rate is intentionally not bounded
+//!     because of known instrument inertia / barometric noise);
+//!     BDS 44 temperature in [-80, +60] °C and wind speed ≤ 250 kt;
+//!     BDS 45 static temperature in [-80, +60] °C;
+//!     BDS 21 registration with at most 2 `#` placeholders.
+//!   - **Density-based scoring** combined with **within-record cross-field
+//!     penalties**: for the candidates in BDS 05 / 40 / 44 / 45 / 50 / 60,
+//!     a mean log-density across decoded fields ([`density`]) is summed
+//!     with the cross-field penalty ([`penalty`], which currently covers
+//!     BDS 50 |TAS−GS| and roll/track-rate sign, and BDS 60 IAS/Mach
+//!     ratio). The candidate is rejected when the combined score falls
+//!     below [`density::DENSITY_THRESHOLD`] (default `−3.0`).
+//!   - Strict capability-bit constraints from ICAO Doc 9871 on BDS 17 / 18.
+//!   - The candidate set in [`infer_bds`] also includes BDS 06 / 08 / 09 /
+//!     61 / 62.
+//!
+//! * **Minimal (`--no-default-features`)** — baseline strategy. Only
+//!   reserved bits, status-bit consistency and spec-mandated value ranges
+//!   are enforced; the relaxed capability bits on BDS 17 / 18 are
+//!   accepted; BDS 06 / 08 / 09 / 61 / 62 are excluded from [`infer_bds`].
 //!
 //! Decoder bug-fixes (BDS 05 / 06 / 08 5-bit offset, BDS 10 prepend, BDS 21
-//! dash-placeholder mapping, BDS 17 `bds20` accepting 0) are applied
-//! unconditionally in both strategies.
+//! dash-placeholder mapping, BDS 17 `bds20` accepting 0, BDS 44 temperature
+//! sign-bit wrap-around fallback) are applied unconditionally in both
+//! strategies.
 
 pub mod bds05;
 pub mod bds06;
@@ -44,6 +61,10 @@ pub mod bds60;
 pub mod bds61;
 pub mod bds62;
 pub mod bds65;
+#[cfg(feature = "bds-infer")]
+pub mod density;
+#[cfg(feature = "bds-infer")]
+pub mod penalty;
 
 use self::bds05::AirbornePosition;
 use self::bds06::SurfacePosition;
@@ -184,13 +205,60 @@ fn extract_tc(payload: &[u8]) -> u8 {
     payload[0] >> 3
 }
 
+/// Apply the combined density + cross-field score gate to a successfully
+/// decoded candidate.
+///
+/// With `bds-infer` enabled (default), the candidate's combined score is
+///
+/// ```text
+///     score = mean(field_log_densities)   // density.rs
+///           + cross_field_penalty         // penalty.rs
+/// ```
+///
+/// and the candidate is rejected with [`DecodingError::DecodingFailed`]
+/// when the combined score falls below [`density::DENSITY_THRESHOLD`]
+/// (default `−3.0`). Candidates with no density-scored field and a zero
+/// cross-field penalty are accepted unconditionally (no signal). Without
+/// `bds-infer`, this function is the identity.
+#[inline]
+fn apply_score_gate(
+    result: Result<DecodedBds, DecodingError>,
+) -> Result<DecodedBds, DecodingError> {
+    #[cfg(feature = "bds-infer")]
+    {
+        match result {
+            Ok(decoded) => {
+                let mean = density::density_score(&decoded);
+                let pen = penalty::penalty(&decoded);
+                if mean.is_none() && pen == 0.0 {
+                    return Ok(decoded);
+                }
+                let score = mean.unwrap_or(0.0) + pen;
+                if score < density::DENSITY_THRESHOLD {
+                    Err(DecodingError::DecodingFailed(format!(
+                        "combined score {score:.2} below threshold {:.1}",
+                        density::DENSITY_THRESHOLD
+                    )))
+                } else {
+                    Ok(decoded)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+    #[cfg(not(feature = "bds-infer"))]
+    {
+        result
+    }
+}
+
 /// Attempt to decode the BDS payload based on the BDS code
 /// Returns None if decoding fails or BDS type is not supported
 pub fn decode_payload(
     payload: &[u8],
     bds_code: u8,
 ) -> Result<DecodedBds, DecodingError> {
-    match bds_code {
+    let result = match bds_code {
         0x05 => {
             let tc = extract_tc(payload);
             if !((9..=18).contains(&tc) || (20..=22).contains(&tc)) {
@@ -330,7 +398,8 @@ pub fn decode_payload(
                 .map_err(|e| DecodingError::DecodingFailed(e.to_string()))
         }
         _ => Err(DecodingError::InvalidBdsCode(bds_code)),
-    }
+    };
+    apply_score_gate(result)
 }
 
 /// Decode a BDS payload with a required BDS code (strict decoding)
@@ -366,7 +435,7 @@ pub fn decode_bds(
         });
     }
 
-    match bds_code {
+    let result = match bds_code {
         0x05 => {
             let tc = extract_tc(payload);
             if !((9..=18).contains(&tc) || (20..=22).contains(&tc)) {
@@ -519,7 +588,8 @@ pub fn decode_bds(
                 .map_err(|e| DecodingError::DecodingFailed(e.to_string()))
         }
         _ => Err(DecodingError::InvalidBdsCode(bds_code)),
-    }
+    };
+    apply_score_gate(result)
 }
 
 /// Infer possible BDS codes from a Comm-B payload (inference mode)
@@ -530,6 +600,9 @@ pub fn decode_bds(
 ///
 /// # Arguments
 /// * `payload` - The Comm-B data field (typically 7 bytes)
+/// * `icao24` - Optional ICAO 24-bit aircraft address, used to validate BDS 2,1
+///   registration strings against the country-prefix pattern inferred from the
+///   address range. Pass `None` when the address is not available.
 ///
 /// # Returns
 /// * `Vec<DecodedBds>` - All successfully decoded BDS variants, ordered by BDS code
@@ -538,10 +611,10 @@ pub fn decode_bds(
 /// # Example
 /// ```ignore
 /// let payload = vec![0x80, 0x02, 0x04, 0x08, 0x0E, 0x20, 0x47];
-/// let results = infer_bds(&payload);
+/// let results = infer_bds(&payload, None);
 /// // Returns all BDS codes that successfully decode this payload
 /// ```
-pub fn infer_bds(payload: &[u8]) -> Vec<DecodedBds> {
+pub fn infer_bds(payload: &[u8], icao24: Option<u32>) -> Vec<DecodedBds> {
     if payload.is_empty() {
         return Vec::new();
     }
@@ -555,7 +628,52 @@ pub fn infer_bds(payload: &[u8]) -> Vec<DecodedBds> {
     ];
     for bds_code in candidates {
         if let Ok(decoded) = decode_bds(payload, *bds_code) {
+            // P1: icao24-aware registration validation for BDS 2,1.
+            // Rejects phantom BDS 2,1 candidates whose decoded registration
+            // does not match any of the four structural buckets for the
+            // country inferred from the aircraft's ICAO address range.
+            #[cfg(feature = "bds-infer")]
+            if let (DecodedBds::Bds21(ref bds21), Some(addr)) =
+                (&decoded, icao24)
+            {
+                if let Some(reg) = &bds21.aircraft_registration {
+                    if !bds21::validate_registration(reg, addr) {
+                        continue;
+                    }
+                }
+            }
             results.push(decoded);
+        }
+    }
+
+    // P2: winner-take-all.
+    // BDS 1,0 / 2,0 / 3,0 are identified by a mandatory byte-header prefix
+    // (0x10 / 0x20 / 0x30) that no other register produces, making them
+    // high-confidence identifications. BDS 2,1 after passing P1 joins this
+    // tier. When any such candidate is present, it evicts every other
+    // surviving candidate — phantom co-survivors on the same payload cannot
+    // be genuine.
+    #[cfg(feature = "bds-infer")]
+    {
+        let has_winner = results.iter().any(|d| {
+            matches!(
+                d,
+                DecodedBds::Bds10(_)
+                    | DecodedBds::Bds20(_)
+                    | DecodedBds::Bds21(_)
+                    | DecodedBds::Bds30(_)
+            )
+        });
+        if has_winner {
+            results.retain(|d| {
+                matches!(
+                    d,
+                    DecodedBds::Bds10(_)
+                        | DecodedBds::Bds20(_)
+                        | DecodedBds::Bds21(_)
+                        | DecodedBds::Bds30(_)
+                )
+            });
         }
     }
 

--- a/crates/rs1090/src/decode/bds/mod.rs
+++ b/crates/rs1090/src/decode/bds/mod.rs
@@ -14,7 +14,7 @@
 //!     BDS 05 altitude ≤ 50 000 ft;
 //!     BDS 40 selected MCP / FMS altitude ≤ 50 000 ft and barometric setting
 //!     in [800, 1200] mb;
-//!     BDS 50 groundspeed ≤ 700 kt, TAS ≤ 600 kt, |roll| ≤ 45°;
+//!     BDS 50 groundspeed ≤ 700 kt, TAS in [80, 600] kt, |roll| ≤ 45°;
 //!     BDS 60 IAS ≤ 500 kt, Mach ≤ 1, |vrate_inertial| ≤ 6 000 ft/min
 //!     (the *barometric* altitude rate is intentionally not bounded
 //!     because of known instrument inertia / barometric noise);
@@ -221,34 +221,39 @@ fn extract_tc(payload: &[u8]) -> u8 {
 /// cross-field penalty are accepted unconditionally (no signal). Without
 /// `bds-infer`, this function is the identity.
 #[inline]
-fn apply_score_gate(
-    result: Result<DecodedBds, DecodingError>,
-) -> Result<DecodedBds, DecodingError> {
+pub(crate) fn validate_score_gate(
+    decoded: &DecodedBds,
+) -> Result<(), DecodingError> {
     #[cfg(feature = "bds-infer")]
     {
-        match result {
-            Ok(decoded) => {
-                let mean = density::density_score(&decoded);
-                let pen = penalty::penalty(&decoded);
-                if mean.is_none() && pen == 0.0 {
-                    return Ok(decoded);
-                }
-                let score = mean.unwrap_or(0.0) + pen;
-                if score < density::DENSITY_THRESHOLD {
-                    Err(DecodingError::DecodingFailed(format!(
-                        "combined score {score:.2} below threshold {:.1}",
-                        density::DENSITY_THRESHOLD
-                    )))
-                } else {
-                    Ok(decoded)
-                }
-            }
-            Err(e) => Err(e),
+        let mean = density::density_score(decoded);
+        let pen = penalty::penalty(decoded);
+        if mean.is_none() && pen == 0.0 {
+            return Ok(());
+        }
+        let score = mean.unwrap_or(0.0) + pen;
+        if score < density::DENSITY_THRESHOLD {
+            Err(DecodingError::DecodingFailed(format!(
+                "combined score {score:.2} below threshold {:.1}",
+                density::DENSITY_THRESHOLD
+            )))
+        } else {
+            Ok(())
         }
     }
     #[cfg(not(feature = "bds-infer"))]
     {
-        result
+        let _ = decoded;
+        Ok(())
+    }
+}
+
+fn apply_score_gate(
+    result: Result<DecodedBds, DecodingError>,
+) -> Result<DecodedBds, DecodingError> {
+    match result {
+        Ok(decoded) => validate_score_gate(&decoded).map(|()| decoded),
+        Err(e) => Err(e),
     }
 }
 
@@ -628,7 +633,7 @@ pub fn infer_bds(payload: &[u8], icao24: Option<u32>) -> Vec<DecodedBds> {
     ];
     for bds_code in candidates {
         if let Ok(decoded) = decode_bds(payload, *bds_code) {
-            // P1: icao24-aware registration validation for BDS 2,1.
+            // icao24-aware registration validation for BDS 2,1.
             // Rejects phantom BDS 2,1 candidates whose decoded registration
             // does not match any of the four structural buckets for the
             // country inferred from the aircraft's ICAO address range.
@@ -646,13 +651,13 @@ pub fn infer_bds(payload: &[u8], icao24: Option<u32>) -> Vec<DecodedBds> {
         }
     }
 
-    // P2: winner-take-all.
+    // Winner-take-all.
     // BDS 1,0 / 2,0 / 3,0 are identified by a mandatory byte-header prefix
     // (0x10 / 0x20 / 0x30) that no other register produces, making them
-    // high-confidence identifications. BDS 2,1 after passing P1 joins this
-    // tier. When any such candidate is present, it evicts every other
-    // surviving candidate — phantom co-survivors on the same payload cannot
-    // be genuine.
+    // high-confidence identifications. BDS 2,1 is deliberately excluded from
+    // this tier: registration validation helps, but registration-looking
+    // phantoms are still common enough that they must not evict other
+    // surviving candidates.
     #[cfg(feature = "bds-infer")]
     {
         let has_winner = results.iter().any(|d| {
@@ -660,7 +665,6 @@ pub fn infer_bds(payload: &[u8], icao24: Option<u32>) -> Vec<DecodedBds> {
                 d,
                 DecodedBds::Bds10(_)
                     | DecodedBds::Bds20(_)
-                    | DecodedBds::Bds21(_)
                     | DecodedBds::Bds30(_)
             )
         });
@@ -670,7 +674,6 @@ pub fn infer_bds(payload: &[u8], icao24: Option<u32>) -> Vec<DecodedBds> {
                     d,
                     DecodedBds::Bds10(_)
                         | DecodedBds::Bds20(_)
-                        | DecodedBds::Bds21(_)
                         | DecodedBds::Bds30(_)
                 )
             });

--- a/crates/rs1090/src/decode/bds/penalty.rs
+++ b/crates/rs1090/src/decode/bds/penalty.rs
@@ -1,0 +1,91 @@
+//! Within-record cross-field penalties for decoded BDS candidates.
+//!
+//! For each candidate, [`penalty`] returns a **soft** value (always ≤ 0)
+//! that captures aerodynamically or kinematically inconsistent
+//! combinations of fields jointly decoded from the same Comm-B payload:
+//!
+//! * **BDS 50** — `−|TAS − groundspeed| / 100` (continuous; the airframe
+//!   limit on |wind| ≈ 200 kt sets a soft anchor at penalty ≈ −2.0).
+//! * **BDS 50** — `roll` × `track_rate` opposite sign during a turn:
+//!   when `|roll| > 5°` and `|track_rate| > 0.3°/s`, mismatched signs
+//!   contribute a flat `−2.0` penalty.
+//! * **BDS 60** — `IAS / Mach` ratio outside `[250, 800]` kt: flat `−3.0`
+//!   penalty (atmospheric physics constrains the ratio to this range).
+//!
+//! The penalty is summed with the [density score](super::density) and the
+//! combined value is gated against [`super::density::DENSITY_THRESHOLD`].
+//! It is invoked from the same post-decode hook as the density rule,
+//! replacing what used to be field-reader hard rejects on the same
+//! relations.
+//!
+//! This module is only compiled when the `bds-infer` feature is enabled.
+
+use super::DecodedBds;
+
+/// Cross-field penalty contributed by BDS-50 / BDS-60 relations
+/// (always ≤ 0).
+#[must_use]
+pub fn penalty(decoded: &DecodedBds) -> f64 {
+    let mut p = 0.0_f64;
+    match decoded {
+        DecodedBds::Bds50(t) => {
+            // |TAS − GS| / 100, continuous proxy for headwind/tailwind.
+            if let (Some(tas), Some(gs)) = (t.true_airspeed, t.groundspeed) {
+                p -= (f64::from(tas) - f64::from(gs)).abs() / 100.0;
+            }
+            // Roll vs track_rate: signs must agree during a real turn.
+            if let (Some(roll), Some(rate)) = (t.roll_angle, t.track_rate) {
+                if roll.abs() > 5.0
+                    && rate.abs() > 0.3
+                    && (roll > 0.0) != (rate > 0.0)
+                {
+                    p -= 2.0;
+                }
+            }
+        }
+        DecodedBds::Bds60(h) => {
+            // IAS / Mach ratio bounded by atmospheric physics.
+            if let (Some(ias), Some(mach)) =
+                (h.indicated_airspeed, h.mach_number)
+            {
+                if mach > 0.0 {
+                    let ratio = f64::from(ias) / mach;
+                    if !(250.0..=800.0).contains(&ratio) {
+                        p -= 3.0;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::bds::{decode_bds, DecodedBds};
+    use hexlit::hex;
+
+    /// Cruise-typical BDS 50 record: small |TAS-GS|, low roll/track-rate,
+    /// signs agree. Penalty stays close to zero.
+    #[test]
+    fn cruise_bds50_small_penalty() {
+        let payload = hex!("A0001838CA3E51B250C38D000000");
+        let mb = &payload[4..11];
+        if let Ok(d @ DecodedBds::Bds50(_)) = decode_bds(mb, 0x50) {
+            let p = penalty(&d);
+            assert!(p > -1.0, "penalty for cruise BDS 50 = {p}");
+        }
+    }
+
+    /// A BDS 30 candidate exposes no fields touched by the cross-field
+    /// rules and therefore receives a zero penalty.
+    #[test]
+    fn empty_decoded_bds_no_penalty() {
+        let mb = hex!("30000000000000");
+        if let Ok(d) = decode_bds(&mb, 0x30) {
+            assert_eq!(penalty(&d), 0.0);
+        }
+    }
+}

--- a/crates/rs1090/src/decode/cat48.rs
+++ b/crates/rs1090/src/decode/cat48.rs
@@ -513,7 +513,7 @@ pub struct BdsRecord {
     pub decoded: Result<DecodedBds, DecodingError>,
 
     /// Inferred BDS codes from payload (using infer_bds)
-    #[deku(skip, default = "super::bds::infer_bds(&payload)")]
+    #[deku(skip, default = "super::bds::infer_bds(&payload, None)")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub inferred: Vec<DecodedBds>,
 }

--- a/crates/rs1090/src/decode/cat48.rs
+++ b/crates/rs1090/src/decode/cat48.rs
@@ -36,11 +36,14 @@
 //! | 28 | RE | Reserved Expansion Field | Explicit |
 
 use super::bds::{
-    bds08::callsign_read, decode_payload, DecodedBds, DecodingError,
+    bds08::callsign_read, decode_payload, infer_bds, DecodedBds, DecodingError,
 };
+use super::cpr::Position;
 use super::ICAO;
 use deku::prelude::*;
 use serde::{Serialize, Serializer};
+#[cfg(feature = "bds-infer")]
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Serialize a u8 as a lowercase hex string (e.g., 0x40 → "40")
 fn serialize_u8_as_hex<S: Serializer>(v: &u8, s: S) -> Result<S::Ok, S::Error> {
@@ -516,6 +519,207 @@ pub struct BdsRecord {
     #[deku(skip, default = "super::bds::infer_bds(&payload, None)")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub inferred: Vec<DecodedBds>,
+}
+
+#[cfg(feature = "bds-infer")]
+#[derive(Default)]
+struct Cat48AircraftState {
+    seen: BTreeSet<u8>,
+}
+
+#[cfg(feature = "bds-infer")]
+impl Cat48AircraftState {
+    fn record(&mut self, code: u8) {
+        if !matches!(code, 0x17..=0x19) {
+            self.seen.insert(code);
+        }
+    }
+}
+
+#[cfg(feature = "bds-infer")]
+fn destination_position(
+    start: Position,
+    bearing_deg: f64,
+    distance_nm: f64,
+) -> Position {
+    let lat1 = start.latitude.to_radians();
+    let lon1 = start.longitude.to_radians();
+    let bearing = bearing_deg.to_radians();
+    let angular = distance_nm / 3440.065_f64;
+    let lat2 = (lat1.sin() * angular.cos()
+        + lat1.cos() * angular.sin() * bearing.cos())
+    .asin();
+    let lon2 = lon1
+        + (bearing.sin() * angular.sin() * lat1.cos())
+            .atan2(angular.cos() - lat1.sin() * lat2.sin());
+    Position {
+        latitude: lat2.to_degrees(),
+        longitude: (lon2.to_degrees() + 540.0) % 360.0 - 180.0,
+    }
+}
+
+#[cfg(feature = "bds-infer")]
+fn measured_position(
+    record: &Cat48Record,
+    radar: Position,
+) -> Option<Position> {
+    let measured = record.measured_position.as_ref()?;
+    let altitude_nm = f64::from(record.flight_level?) / 6076.12_f64;
+    let range2 = measured.rho * measured.rho;
+    let altitude2 = altitude_nm * altitude_nm;
+    if range2 <= altitude2 {
+        return None;
+    }
+    Some(destination_position(
+        radar,
+        measured.theta,
+        (range2 - altitude2).sqrt(),
+    ))
+}
+
+#[cfg(feature = "bds-infer")]
+fn gicb_consistent(candidate: &DecodedBds, seen: &BTreeSet<u8>) -> bool {
+    match candidate {
+        DecodedBds::Bds17(b) => {
+            if seen.contains(&0x05) && !b.bds05 {
+                return false;
+            }
+            if seen.contains(&0x06) && !b.bds06 {
+                return false;
+            }
+            if seen.contains(&0x08) && !b.bds08 {
+                return false;
+            }
+            if seen.contains(&0x09) && !b.bds09 {
+                return false;
+            }
+            if seen.contains(&0x20) && !b.bds20 {
+                return false;
+            }
+            if seen.contains(&0x40) && !b.bds40 {
+                return false;
+            }
+            if seen.contains(&0x50) && !b.bds50 {
+                return false;
+            }
+            if seen.contains(&0x60) && !b.bds60 {
+                return false;
+            }
+            true
+        }
+        DecodedBds::Bds18(b) => {
+            if seen.contains(&0x05) && !b.bds05 {
+                return false;
+            }
+            if seen.contains(&0x06) && !b.bds06 {
+                return false;
+            }
+            if seen.contains(&0x08) && !b.bds08 {
+                return false;
+            }
+            if seen.contains(&0x09) && !b.bds09 {
+                return false;
+            }
+            if seen.contains(&0x10) && !b.bds10 {
+                return false;
+            }
+            if seen.contains(&0x20) && !b.bds20 {
+                return false;
+            }
+            if seen.contains(&0x21) && !b.bds21 {
+                return false;
+            }
+            if seen.contains(&0x30) && !b.bds30 {
+                return false;
+            }
+            true
+        }
+        _ => true,
+    }
+}
+
+#[cfg(feature = "bds-infer")]
+fn is_gicb(candidate: &DecodedBds) -> bool {
+    matches!(
+        candidate,
+        DecodedBds::Bds17(_) | DecodedBds::Bds18(_) | DecodedBds::Bds19(_)
+    )
+}
+
+#[cfg(feature = "bds-infer")]
+fn filter_bds05(
+    candidate: &DecodedBds,
+    altitude: Option<i32>,
+    reference: Option<Position>,
+) -> bool {
+    let DecodedBds::Bds05(msg) = candidate else {
+        return true;
+    };
+    if let (Some(candidate_alt), Some(reference_alt)) = (msg.alt, altitude) {
+        if (candidate_alt - reference_alt).abs() > 100 {
+            return false;
+        }
+    }
+    if let Some(reference) = reference {
+        if let Some(position) = super::cpr::airborne_position_with_reference(
+            msg,
+            reference.latitude,
+            reference.longitude,
+        ) {
+            return super::cpr::distance_nm(&position, &reference) <= 5.0;
+        }
+        return false;
+    }
+    true
+}
+
+#[cfg(feature = "bds-infer")]
+pub fn refine_inferred_bds(
+    records: &mut [Cat48Record],
+    radar: Option<Position>,
+) {
+    let mut aircraft: BTreeMap<ICAO, Cat48AircraftState> = BTreeMap::new();
+    for record in records {
+        let icao = record.aircraft_address;
+        let reference =
+            radar.and_then(|radar| measured_position(record, radar));
+        let seen = icao
+            .and_then(|icao| {
+                aircraft.get(&icao).map(|state| state.seen.clone())
+            })
+            .unwrap_or_default();
+
+        if let Some(mb) = &mut record.mode_s_mb_data {
+            for bds_record in &mut mb.records {
+                bds_record.inferred =
+                    infer_bds(&bds_record.payload, icao.map(|addr| addr.0))
+                        .into_iter()
+                        .filter(|candidate| {
+                            filter_bds05(
+                                candidate,
+                                record.flight_level,
+                                reference,
+                            )
+                        })
+                        .collect();
+
+                if bds_record.inferred.len() > 1
+                    && bds_record.inferred.iter().any(|c| !is_gicb(c))
+                {
+                    bds_record
+                        .inferred
+                        .retain(|candidate| gicb_consistent(candidate, &seen));
+                }
+            }
+        }
+
+        if let (Some(icao), Some(mb)) = (icao, &record.mode_s_mb_data) {
+            let state = aircraft.entry(icao).or_default();
+            for bds_record in &mb.records {
+                state.record(bds_record.bds_code);
+            }
+        }
+    }
 }
 
 impl BdsRecord {

--- a/crates/rs1090/src/decode/commb.rs
+++ b/crates/rs1090/src/decode/commb.rs
@@ -12,14 +12,24 @@ use super::bds::bds45::MeteorologicalHazardReport;
 use super::bds::bds50::TrackAndTurnReport;
 use super::bds::bds60::HeadingAndSpeedReport;
 use super::bds::bds65::AircraftOperationStatus;
+use super::bds::{validate_score_gate, DecodedBds};
 use super::cpr::AircraftState;
 use super::AC13Field;
 use super::ICAO;
 use deku::{ctx::Order, prelude::*};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use tracing::debug;
+
+macro_rules! keep_scored_candidate {
+    ($result:ident.$field:ident = $value:ident, $variant:ident, $label:literal) => {
+        match validate_score_gate(&DecodedBds::$variant($value.clone())) {
+            Ok(()) => $result.$field = Some($value),
+            Err(e) => debug!("Hypothesis {}: {}", $label, e.to_string()),
+        }
+    };
+}
 
 /**
  * ## Comm-B Data Selector (BDS)
@@ -79,45 +89,48 @@ pub struct DF20DataSelector {
 }
 
 impl DF20DataSelector {
-    /// Sanitize Comm-B data using optional aircraft state context
+    /// Sanitize decoded Comm-B candidates using optional aircraft state context.
     ///
-    /// Current implementation invalidates BDS 5,0 and BDS 6,0 if both are present,
-    /// as this typically indicates unreliable data.
+    /// Applied after all BDS hypotheses have been decoded from the same 56-bit
+    /// payload. The following checks run in order under `bds-infer`:
     ///
-    /// Future implementations will use the context for more sophisticated validation:
-    /// - Check if groundspeed/track changes are physically possible
-    /// - Validate against reference altitude from DF20 header
-    /// - Temporal consistency checks
-    pub fn sanitize(&mut self, _context: Option<&CommBContext>) {
-        // Basic validation: if both BDS50 and BDS60 are present, invalidate both
-        // This is a common pattern indicating unreliable Comm-B data
-        if self.bds50.is_some() && self.bds60.is_some() {
-            self.bds50 = None;
-            self.bds60 = None;
+    /// 1. Reject a BDS 0,5 candidate whose decoded altitude differs by more
+    ///    than 100 ft from [`CommBContext::last_altitude`]. For a genuine
+    ///    BDS 0,5, both values come from the same on-board barometric sensor
+    ///    and must agree within Mode-C quantisation (25 ft). For a phantom
+    ///    they are uncorrelated.
+    ///
+    /// 2. Reject a BDS 2,1 candidate whose registration string does not match
+    ///    any of the four structural buckets for the country inferred from
+    ///    [`CommBContext::icao24`].
+    ///
+    /// 3. Winner-take-all: when a high-confidence candidate (BDS 1,0, 2,0,
+    ///    or 3,0 by byte-header) is present, evict all other candidates.
+    ///    BDS 2,1 is validated but is not used as a winner because short
+    ///    registration-looking phantoms are too common.
+    ///
+    /// 4. Drop a GICB candidate (BDS 1,7 / 1,8 / 1,9) whose capability
+    ///    bitmap contradicts [`CommBContext::seen_bds`], but only as a
+    ///    tie-breaker (at least one non-GICB candidate must also survive).
+    ///
+    /// 5. Reject a BDS 0,5 candidate whose locally-decoded CPR position
+    ///    differs by more than 5 NM from [`CommBContext::last_position`].
+    ///
+    /// Without `bds-infer` only the legacy BDS 5,0 × BDS 6,0 mutual eviction
+    /// is applied.
+    pub fn sanitize(&mut self, context: Option<&CommBContext<'_>>) {
+        #[cfg(feature = "bds-infer")]
+        if let Some(ctx) = context {
+            sanitize_candidates(self, ctx);
         }
-
-        // Future: context-based validation
-        // if let Some(ctx) = context {
-        //     // Validate BDS 5,0 groundspeed against last known value
-        //     if let Some(bds50) = &self.bds50 {
-        //         if let (Some(gs), Some(last_gs)) = (bds50.groundspeed, ctx.last_groundspeed) {
-        //             // Check if change is physically possible (e.g., < 100 kt/s)
-        //             if (gs as f64 - last_gs).abs() > 100.0 {
-        //                 self.bds50 = None;
-        //             }
-        //         }
-        //     }
-        //
-        //     // Validate against reference altitude from DF20 AC13 field
-        //     if let (Some(ref_alt), Some(bds40)) = (ctx.reference_altitude, &self.bds40) {
-        //         if let Some(sel_alt) = bds40.selected_altitude_mcp {
-        //             // Selected altitude should be reasonably close to current altitude
-        //             if (sel_alt as i32 - ref_alt).abs() > 10000 {
-        //                 self.bds40 = None;
-        //             }
-        //         }
-        //     }
-        // }
+        #[cfg(not(feature = "bds-infer"))]
+        {
+            let _ = context;
+            if self.bds50.is_some() && self.bds60.is_some() {
+                self.bds50 = None;
+                self.bds60 = None;
+            }
+        }
     }
 }
 
@@ -171,32 +184,389 @@ pub struct DF21DataSelector {
 }
 
 impl DF21DataSelector {
-    /// Sanitize Comm-B data using optional aircraft state context
+    /// Sanitize decoded Comm-B candidates.
     ///
-    /// See [`DF20DataSelector::sanitize`] for details.
-    pub fn sanitize(&mut self, _context: Option<&CommBContext>) {
-        if self.bds50.is_some() && self.bds60.is_some() {
-            self.bds50 = None;
-            self.bds60 = None;
+    /// See [`DF20DataSelector::sanitize`] for the full rule description.
+    pub fn sanitize(&mut self, context: Option<&CommBContext<'_>>) {
+        #[cfg(feature = "bds-infer")]
+        if let Some(ctx) = context {
+            sanitize_candidates(self, ctx);
+        }
+        #[cfg(not(feature = "bds-infer"))]
+        {
+            let _ = context;
+            if self.bds50.is_some() && self.bds60.is_some() {
+                self.bds50 = None;
+                self.bds60 = None;
+            }
         }
     }
 }
 
-/// Context for Comm-B message validation and sanitization
+/// Context for Comm-B message validation and sanitization.
 ///
-/// This context is used to validate Comm-B data against known aircraft state.
-/// Currently used for basic validation (e.g., invalidating BDS 5,0 and 6,0 if both present).
-/// Future implementations will use this for more sophisticated validation based on
-/// temporal consistency, physical constraints, and cross-field validation.
+/// Passed to [`DF20DataSelector::sanitize`] and [`DF21DataSelector::sanitize`].
+/// All fields are optional so callers can populate only what they have.
 #[derive(Debug, Default, Clone)]
-pub struct CommBContext {
-    /// Reference altitude from DF20 AC13 field (for cross-validation)
-    pub reference_altitude: Option<i32>,
-    // Future: Add more fields when we have a proper aircraft tracking structure
-    // pub last_altitude: Option<i32>,
-    // pub last_groundspeed: Option<f64>,
-    // pub last_track: Option<f64>,
-    // pub last_timestamp: Option<f64>,
+pub struct CommBContext<'a> {
+    /// Most recent barometric altitude for this aircraft, in feet.
+    ///
+    /// For DF 20, use the outer AC13 altitude from the same message (same
+    /// barometric sensor, should agree within Mode-C quantization with any
+    /// genuine BDS 0,5 candidate). For DF 21, or when no DF 20 altitude is
+    /// available, use the most recent ADS-B barometric altitude from this
+    /// aircraft. Either way, a BDS 0,5 candidate whose decoded altitude
+    /// differs by more than 100 ft is almost certainly a phantom.
+    pub last_altitude: Option<i32>,
+
+    /// ICAO 24-bit aircraft address.
+    ///
+    /// Used to validate a surviving BDS 2,1 candidate's registration
+    /// string against the country-prefix patterns inferred from this address.
+    pub icao24: Option<u32>,
+
+    /// Set of BDS register codes the aircraft has been observed transmitting.
+    ///
+    /// Used for the GICB bitmap tie-breaker: drop a GICB candidate (BDS 1,7 / 1,8 / 1,9)
+    /// whose capability bitmap contradicts this evidence set, but only when at
+    /// least one non-GICB candidate also survives.
+    pub seen_bds: Option<&'a BTreeSet<u8>>,
+
+    /// Most recent decoded position for this aircraft.
+    ///
+    /// Used for CPR position cross-validation: locally CPR-decode the BDS 0,5
+    /// candidate using this as the reference; reject when the decoded position
+    /// differs by more than 5 NM. Phantom CPR bits scatter uniformly over a
+    /// ~360 × 360 NM cell; genuine positions cluster within 1–2 NM of the
+    /// reference.
+    pub last_position: Option<super::cpr::Position>,
+
+    /// BDS codes the aircraft's capability report declares as supported,
+    /// once enough consistent reports have been seen.
+    ///
+    /// When present, any surviving candidate whose BDS code appears in the
+    /// BDS 1,7 schema but is absent from this set is rejected — the aircraft
+    /// has declared it does not support that register.
+    pub stable_supported_bds: Option<&'a BTreeSet<u8>>,
+}
+
+/// Trait abstracting the candidate fields common to both [`DF20DataSelector`]
+/// and [`DF21DataSelector`], so the sanitize logic can be written once.
+#[cfg(feature = "bds-infer")]
+#[allow(dead_code)]
+trait CommBCandidates {
+    fn bds05_alt(&self) -> Option<i32>;
+    fn bds05_msg(&self) -> Option<&AirbornePosition>;
+    fn clear_bds05(&mut self);
+    fn bds21_reg(&self) -> Option<&str>;
+    fn clear_bds21(&mut self);
+    fn has_bds10(&self) -> bool;
+    fn has_bds20(&self) -> bool;
+    fn has_bds21(&self) -> bool;
+    fn has_bds30(&self) -> bool;
+    fn has_bds17(&self) -> bool;
+    fn has_bds18(&self) -> bool;
+    fn has_bds19(&self) -> bool;
+    fn has_non_gicb(&self) -> bool;
+    fn clear_bds17(&mut self);
+    fn clear_bds18(&mut self);
+    fn clear_bds19(&mut self);
+    fn clear_non_winner(&mut self);
+    fn gicb_bitmap_consistent(&self, reg: &BTreeSet<u8>) -> (bool, bool, bool);
+    /// Reject candidates for BDS codes in the BDS 1,7 schema that the
+    /// aircraft has declared unsupported (i.e. absent from `supported`).
+    fn reject_unsupported(&mut self, supported: &BTreeSet<u8>);
+}
+
+#[cfg(feature = "bds-infer")]
+macro_rules! impl_commb_candidates {
+    ($t:ty) => {
+        impl CommBCandidates for $t {
+            fn bds05_alt(&self) -> Option<i32> {
+                self.bds05.as_ref().and_then(|b| b.alt)
+            }
+            fn bds05_msg(&self) -> Option<&AirbornePosition> {
+                self.bds05.as_ref()
+            }
+            fn clear_bds05(&mut self) {
+                self.bds05 = None;
+            }
+            fn bds21_reg(&self) -> Option<&str> {
+                self.bds21
+                    .as_ref()
+                    .and_then(|b| b.aircraft_registration.as_deref())
+            }
+            fn clear_bds21(&mut self) {
+                self.bds21 = None;
+            }
+            fn has_bds10(&self) -> bool {
+                self.bds10.is_some()
+            }
+            fn has_bds20(&self) -> bool {
+                self.bds20.is_some()
+            }
+            fn has_bds21(&self) -> bool {
+                self.bds21.is_some()
+            }
+            fn has_bds30(&self) -> bool {
+                self.bds30.is_some()
+            }
+            fn has_bds17(&self) -> bool {
+                self.bds17.is_some()
+            }
+            fn has_bds18(&self) -> bool {
+                self.bds18.is_some()
+            }
+            fn has_bds19(&self) -> bool {
+                self.bds19.is_some()
+            }
+            fn has_non_gicb(&self) -> bool {
+                // any surviving candidate that is NOT a GICB register
+                self.bds05.is_some()
+                    || self.bds10.is_some()
+                    || self.bds20.is_some()
+                    || self.bds21.is_some()
+                    || self.bds30.is_some()
+                    || self.bds40.is_some()
+                    || self.bds44.is_some()
+                    || self.bds45.is_some()
+                    || self.bds50.is_some()
+                    || self.bds60.is_some()
+                    || self.bds65.is_some()
+            }
+            fn clear_bds17(&mut self) {
+                self.bds17 = None;
+            }
+            fn clear_bds18(&mut self) {
+                self.bds18 = None;
+            }
+            fn clear_bds19(&mut self) {
+                self.bds19 = None;
+            }
+            /// Evict every candidate that is NOT in the high-confidence tier.
+            fn clear_non_winner(&mut self) {
+                self.bds05 = None;
+                self.bds17 = None;
+                self.bds18 = None;
+                self.bds19 = None;
+                self.bds40 = None;
+                self.bds44 = None;
+                self.bds45 = None;
+                self.bds50 = None;
+                self.bds60 = None;
+                self.bds65 = None;
+            }
+            /// Returns (bds17_ok, bds18_ok, bds19_ok): whether each GICB
+            /// candidate's bitmap is consistent with the evidence set.
+            ///
+            /// For each code in `seen` (registers this aircraft has been
+            /// observed transmitting) that appears in the GICB schema, the
+            /// corresponding capability bit in the decoded struct must be
+            /// `true`. A phantom candidate that happens to pass the GICB
+            /// decoder will satisfy this by chance only.
+            fn gicb_bitmap_consistent(
+                &self,
+                seen: &BTreeSet<u8>,
+            ) -> (bool, bool, bool) {
+                // BDS 1,7 schema: the capability bits it can represent
+                // as `true`/`false`.
+                let b17 = self.bds17.as_ref().map_or(true, |b| {
+                    // For every code in `seen` that BDS 1,7 tracks,
+                    // the bit must be set to true.
+                    if seen.contains(&0x05u8) && !b.bds05 {
+                        return false;
+                    }
+                    if seen.contains(&0x06u8) && !b.bds06 {
+                        return false;
+                    }
+                    if seen.contains(&0x08u8) && !b.bds08 {
+                        return false;
+                    }
+                    if seen.contains(&0x09u8) && !b.bds09 {
+                        return false;
+                    }
+                    if seen.contains(&0x20u8) && !b.bds20 {
+                        return false;
+                    }
+                    if seen.contains(&0x40u8) && !b.bds40 {
+                        return false;
+                    }
+                    if seen.contains(&0x50u8) && !b.bds50 {
+                        return false;
+                    }
+                    if seen.contains(&0x60u8) && !b.bds60 {
+                        return false;
+                    }
+                    true
+                });
+                let b18 = self.bds18.as_ref().map_or(true, |b| {
+                    // BDS 1,8 schema covers the lower register range.
+                    if seen.contains(&0x05u8) && !b.bds05 {
+                        return false;
+                    }
+                    if seen.contains(&0x06u8) && !b.bds06 {
+                        return false;
+                    }
+                    if seen.contains(&0x08u8) && !b.bds08 {
+                        return false;
+                    }
+                    if seen.contains(&0x09u8) && !b.bds09 {
+                        return false;
+                    }
+                    if seen.contains(&0x10u8) && !b.bds10 {
+                        return false;
+                    }
+                    if seen.contains(&0x17u8) && !b.bds17 {
+                        return false;
+                    }
+                    if seen.contains(&0x18u8) && !b.bds18 {
+                        return false;
+                    }
+                    if seen.contains(&0x19u8) && !b.bds19 {
+                        return false;
+                    }
+                    if seen.contains(&0x20u8) && !b.bds20 {
+                        return false;
+                    }
+                    if seen.contains(&0x21u8) && !b.bds21 {
+                        return false;
+                    }
+                    if seen.contains(&0x30u8) && !b.bds30 {
+                        return false;
+                    }
+                    true
+                });
+                let b19 = self.bds19.as_ref().map_or(true, |_b| {
+                    // BDS 1,9 is always treated as consistent — very few
+                    // false positives survive to this point anyway.
+                    true
+                });
+                (b17, b18, b19)
+            }
+            fn reject_unsupported(&mut self, supported: &BTreeSet<u8>) {
+                // BDS 1,7 schema: codes it tracks. For each code absent from
+                // `supported`, clear the corresponding candidate if present.
+                if !supported.contains(&0x05u8) {
+                    self.bds05 = None;
+                }
+                // 0x06 surface position: not typically in EHS inference scope
+                if !supported.contains(&0x20u8) {
+                    self.bds20 = None;
+                }
+                if !supported.contains(&0x21u8) {
+                    self.bds21 = None;
+                }
+                if !supported.contains(&0x40u8) {
+                    self.bds40 = None;
+                }
+                if !supported.contains(&0x44u8) {
+                    self.bds44 = None;
+                }
+                if !supported.contains(&0x45u8) {
+                    self.bds45 = None;
+                }
+                if !supported.contains(&0x50u8) {
+                    self.bds50 = None;
+                }
+                if !supported.contains(&0x60u8) {
+                    self.bds60 = None;
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "bds-infer")]
+impl_commb_candidates!(DF20DataSelector);
+#[cfg(feature = "bds-infer")]
+impl_commb_candidates!(DF21DataSelector);
+
+/// Apply contextual checks to any set of surviving BDS candidates.
+#[cfg(feature = "bds-infer")]
+fn sanitize_candidates<C: CommBCandidates>(
+    sel: &mut C,
+    ctx: &CommBContext<'_>,
+) {
+    // Altitude cross-check: reject a BDS 0,5 candidate whose decoded altitude
+    // differs > 100 ft from the last known barometric altitude.
+    // For a genuine BDS 0,5 both values come from the same on-board sensor
+    // and must agree within Mode-C quantisation (25 ft); for a phantom they
+    // are uncorrelated.
+    if let (Some(cand_alt), Some(ref_alt)) =
+        (sel.bds05_alt(), ctx.last_altitude)
+    {
+        if (cand_alt - ref_alt).abs() > 100 {
+            sel.clear_bds05();
+        }
+    }
+
+    // Capability-based rejection: once the aircraft's BDS 1,7 capability
+    // set is stable (seen in at least 3 consistent records), reject any
+    // candidate for a BDS code the aircraft has declared unsupported.
+    if let Some(supported) = ctx.stable_supported_bds {
+        sel.reject_unsupported(supported);
+    }
+
+    // Registration validation: reject a BDS 2,1 candidate whose registration
+    // string does not match any of the four structural buckets for the country
+    // inferred from the aircraft's ICAO address range.
+    if let (Some(reg), Some(addr)) =
+        (sel.bds21_reg().map(str::to_owned), ctx.icao24)
+    {
+        if !super::bds::bds21::validate_registration(&reg, addr) {
+            sel.clear_bds21();
+        }
+    }
+
+    // Winner-take-all: BDS 1,0 / 2,0 / 3,0 are identified by a mandatory
+    // byte-header prefix that no other register produces. BDS 2,1 is not a
+    // winner: even after registration validation, short registration-looking
+    // phantoms are common enough that they must not evict other candidates.
+    let has_winner = sel.has_bds10() || sel.has_bds20() || sel.has_bds30();
+    if has_winner {
+        sel.clear_non_winner();
+        return; // GICB and CPR checks are irrelevant once only high-confidence candidates remain
+    }
+
+    // GICB bitmap tie-breaker: drop a GICB candidate (BDS 1,7 / 1,8 / 1,9)
+    // whose capability bitmap contradicts the aircraft's known transmission
+    // history, but only when at least one non-GICB candidate also survives
+    // (singleton GICB records are kept — some legitimate records have
+    // intermittent zero bits due to sub-format / equipment-cycle effects).
+    if let Some(seen) = ctx.seen_bds {
+        if sel.has_non_gicb() {
+            let (b17_ok, b18_ok, _b19_ok) = sel.gicb_bitmap_consistent(seen);
+            if !b17_ok {
+                sel.clear_bds17();
+            }
+            if !b18_ok {
+                sel.clear_bds18();
+            }
+            // BDS 1,9 is always kept (treated as consistent — see above).
+        }
+    }
+
+    // CPR position cross-check: reject a BDS 0,5 candidate whose
+    // locally-decoded position differs by more than 5 NM from the aircraft's
+    // last known position. Phantom CPR bits scatter uniformly over a
+    // ~360 × 360 NM local CPR cell (phantom acceptance ≈ 0.06 % at 5 NM).
+    // Genuine candidates cluster within 1–2 NM of the reference (q99 ≈ 1.6 NM).
+    if let (Some(msg), Some(ref_pos)) =
+        (sel.bds05_msg(), ctx.last_position.as_ref())
+    {
+        use super::cpr::{airborne_position_with_reference, distance_nm};
+        let decoded = airborne_position_with_reference(
+            msg,
+            ref_pos.latitude,
+            ref_pos.longitude,
+        );
+        match decoded {
+            Some(cand_pos) if distance_nm(&cand_pos, ref_pos) <= 5.0 => {}
+            _ => {
+                sel.clear_bds05();
+            }
+        }
+    }
 }
 
 impl fmt::Display for DF21DataSelector {
@@ -279,23 +649,33 @@ impl DekuReader<'_, AC13Field> for DF20DataSelector {
             Err(e) => debug!("Hypothesis BDS30: {}", e.to_string()),
         }
         match SelectedVerticalIntention::try_from(buf.as_slice()) {
-            Ok(bds40) => result.bds40 = Some(bds40),
+            Ok(bds40) => {
+                keep_scored_candidate!(result.bds40 = bds40, Bds40, "BDS40")
+            }
             Err(e) => debug!("Hypothesis BDS40: {}", e.to_string()),
         }
         match MeteorologicalRoutineAirReport::try_from(buf.as_slice()) {
-            Ok(bds44) => result.bds44 = Some(bds44),
+            Ok(bds44) => {
+                keep_scored_candidate!(result.bds44 = bds44, Bds44, "BDS44")
+            }
             Err(e) => debug!("Hypothesis BDS44: {}", e.to_string()),
         }
         match MeteorologicalHazardReport::try_from(buf.as_slice()) {
-            Ok(bds45) => result.bds45 = Some(bds45),
+            Ok(bds45) => {
+                keep_scored_candidate!(result.bds45 = bds45, Bds45, "BDS45")
+            }
             Err(e) => debug!("Hypothesis BDS45: {}", e.to_string()),
         }
         match TrackAndTurnReport::try_from(buf.as_slice()) {
-            Ok(bds50) => result.bds50 = Some(bds50),
+            Ok(bds50) => {
+                keep_scored_candidate!(result.bds50 = bds50, Bds50, "BDS50")
+            }
             Err(e) => debug!("Hypothesis BDS50: {}", e.to_string()),
         }
         match HeadingAndSpeedReport::try_from(buf.as_slice()) {
-            Ok(bds60) => result.bds60 = Some(bds60),
+            Ok(bds60) => {
+                keep_scored_candidate!(result.bds60 = bds60, Bds60, "BDS60")
+            }
             Err(e) => debug!("Hypothesis BDS60: {}", e.to_string()),
         }
 
@@ -386,23 +766,33 @@ impl DekuReader<'_> for DF21DataSelector {
             Err(e) => debug!("Hypothesis BDS30: {}", e.to_string()),
         }
         match SelectedVerticalIntention::try_from(buf.as_slice()) {
-            Ok(bds40) => result.bds40 = Some(bds40),
+            Ok(bds40) => {
+                keep_scored_candidate!(result.bds40 = bds40, Bds40, "BDS40")
+            }
             Err(e) => debug!("Hypothesis BDS40: {}", e.to_string()),
         }
         match MeteorologicalRoutineAirReport::try_from(buf.as_slice()) {
-            Ok(bds44) => result.bds44 = Some(bds44),
+            Ok(bds44) => {
+                keep_scored_candidate!(result.bds44 = bds44, Bds44, "BDS44")
+            }
             Err(e) => debug!("Hypothesis BDS44: {}", e.to_string()),
         }
         match MeteorologicalHazardReport::try_from(buf.as_slice()) {
-            Ok(bds45) => result.bds45 = Some(bds45),
+            Ok(bds45) => {
+                keep_scored_candidate!(result.bds45 = bds45, Bds45, "BDS45")
+            }
             Err(e) => debug!("Hypothesis BDS45: {}", e.to_string()),
         }
         match TrackAndTurnReport::try_from(buf.as_slice()) {
-            Ok(bds50) => result.bds50 = Some(bds50),
+            Ok(bds50) => {
+                keep_scored_candidate!(result.bds50 = bds50, Bds50, "BDS50")
+            }
             Err(e) => debug!("Hypothesis BDS50: {}", e.to_string()),
         }
         match HeadingAndSpeedReport::try_from(buf.as_slice()) {
-            Ok(bds60) => result.bds60 = Some(bds60),
+            Ok(bds60) => {
+                keep_scored_candidate!(result.bds60 = bds60, Bds60, "BDS60")
+            }
             Err(e) => debug!("Hypothesis BDS60: {}", e.to_string()),
         }
 
@@ -441,47 +831,178 @@ impl DekuReader<'_> for DF21DataSelector {
 ///
 /// # let mut message = todo!();
 /// # let aircraft = todo!();
-/// MessageProcessor::new(&mut message, &aircraft)
+/// MessageProcessor::new(&mut message, &mut aircraft)
 ///     .sanitize_commb()
 ///     .finish();
 /// ```
 pub struct MessageProcessor<'a> {
     message: &'a mut super::Message,
-    #[allow(dead_code)] // Reserved for future context-based validation
-    aircraft: &'a BTreeMap<ICAO, AircraftState>,
+    aircraft: &'a mut BTreeMap<ICAO, AircraftState>,
 }
 
 impl<'a> MessageProcessor<'a> {
     /// Create a new message processor
     pub fn new(
         message: &'a mut super::Message,
-        aircraft: &'a BTreeMap<ICAO, AircraftState>,
+        aircraft: &'a mut BTreeMap<ICAO, AircraftState>,
     ) -> Self {
         Self { message, aircraft }
     }
 
     /// Sanitize Comm-B data using aircraft state context
-    ///
-    /// This will invalidate BDS 5,0 and BDS 6,0 if both are present.
-    /// Future implementations will perform more sophisticated validation
-    /// using the aircraft state context.
     pub fn sanitize_commb(self) -> Self {
         use super::DF::*;
 
+        // Resolve per-aircraft state for the icao24 in this message.
+        let icao24_addr: Option<ICAO> = match &self.message.df {
+            CommBAltitudeReply { ap, .. } => Some(ICAO::from(*ap)),
+            CommBIdentityReply { ap, .. } => Some(ICAO::from(*ap)),
+            _ => None,
+        };
+        let state = icao24_addr.as_ref().and_then(|ap| self.aircraft.get(ap));
+
         match &mut self.message.df {
-            CommBAltitudeReply { bds, ac, .. } => {
+            CommBAltitudeReply { bds, ac, ap, .. } => {
                 let context = CommBContext {
-                    reference_altitude: ac.0,
+                    last_altitude: ac
+                        .0
+                        .or_else(|| state.and_then(|s| s.last_altitude())),
+                    icao24: Some(ap.0),
+                    seen_bds: state.map(|s| s.seen_bds()),
+                    last_position: state.and_then(|s| s.last_position()),
+                    stable_supported_bds: state
+                        .and_then(|s| s.stable_supported_bds()),
                 };
                 bds.sanitize(Some(&context));
             }
-            CommBIdentityReply { bds, .. } => {
+            CommBIdentityReply { bds, ap, .. } => {
                 let context = CommBContext {
-                    reference_altitude: None,
+                    last_altitude: state.and_then(|s| s.last_altitude()),
+                    icao24: Some(ap.0),
+                    seen_bds: state.map(|s| s.seen_bds()),
+                    last_position: state.and_then(|s| s.last_position()),
+                    stable_supported_bds: state
+                        .and_then(|s| s.stable_supported_bds()),
                 };
                 bds.sanitize(Some(&context));
             }
             _ => {}
+        }
+        self
+    }
+
+    /// Record observed BDS registers into the per-aircraft evidence set.
+    ///
+    /// Must be called **after** [`sanitize_commb`](Self::sanitize_commb) so
+    /// that only unambiguous (surviving) candidates are recorded. Each
+    /// surviving data register (BDS 0,5 / 1,0 / 2,0 / 2,1 / 3,0 / 4,0 /
+    /// 4,4 / 4,5 / 5,0 / 6,0 / 6,5) updates the aircraft's `seen_bds` set.
+    ///
+    /// GICB capability registers (BDS 1,7 / 1,8 / 1,9) are intentionally
+    /// not recorded: the bitmap tie-breaker checks whether the registers
+    /// *declared* in the capability bitmap have been observed, not whether
+    /// the GICB register itself has been seen.
+    pub fn record_observed_bds(self) -> Self {
+        use super::DF::*;
+        let icao = match &self.message.df {
+            CommBAltitudeReply { ap, .. } => Some(ICAO::from(*ap)),
+            CommBIdentityReply { ap, .. } => Some(ICAO::from(*ap)),
+            _ => None,
+        };
+        if let Some(icao) = icao {
+            if let Some(state) = self.aircraft.get_mut(&icao) {
+                let record = |state: &mut AircraftState, code: u8| {
+                    state.record_bds(code);
+                };
+                // Record only data registers, not GICB capability registers
+                // (0x17 / 0x18 / 0x19), which are never consulted by the
+                // bitmap consistency check.
+                let record_data =
+                    |state: &mut AircraftState, bds: &DF20DataSelector| {
+                        if bds.bds05.is_some() {
+                            record(state, 0x05);
+                        }
+                        if bds.bds10.is_some() {
+                            record(state, 0x10);
+                        }
+                        if bds.bds20.is_some() {
+                            record(state, 0x20);
+                        }
+                        if bds.bds21.is_some() {
+                            record(state, 0x21);
+                        }
+                        if bds.bds30.is_some() {
+                            record(state, 0x30);
+                        }
+                        if bds.bds40.is_some() {
+                            record(state, 0x40);
+                        }
+                        if bds.bds44.is_some() {
+                            record(state, 0x44);
+                        }
+                        if bds.bds45.is_some() {
+                            record(state, 0x45);
+                        }
+                        if bds.bds50.is_some() {
+                            record(state, 0x50);
+                        }
+                        if bds.bds60.is_some() {
+                            record(state, 0x60);
+                        }
+                        if bds.bds65.is_some() {
+                            record(state, 0x65);
+                        }
+                    };
+                match &self.message.df {
+                    CommBAltitudeReply { bds, .. } => {
+                        record_data(state, bds);
+                        if let Some(b17) = &bds.bds17 {
+                            state.update_bds17(b17);
+                        }
+                    }
+                    CommBIdentityReply { bds, .. } => {
+                        // DF21DataSelector has the same fields; use a
+                        // separate arm rather than trying to unify types.
+                        if bds.bds05.is_some() {
+                            record(state, 0x05);
+                        }
+                        if bds.bds10.is_some() {
+                            record(state, 0x10);
+                        }
+                        if bds.bds20.is_some() {
+                            record(state, 0x20);
+                        }
+                        if bds.bds21.is_some() {
+                            record(state, 0x21);
+                        }
+                        if bds.bds30.is_some() {
+                            record(state, 0x30);
+                        }
+                        if bds.bds40.is_some() {
+                            record(state, 0x40);
+                        }
+                        if bds.bds44.is_some() {
+                            record(state, 0x44);
+                        }
+                        if bds.bds45.is_some() {
+                            record(state, 0x45);
+                        }
+                        if bds.bds50.is_some() {
+                            record(state, 0x50);
+                        }
+                        if bds.bds60.is_some() {
+                            record(state, 0x60);
+                        }
+                        if bds.bds65.is_some() {
+                            record(state, 0x65);
+                        }
+                        if let Some(b17) = &bds.bds17 {
+                            state.update_bds17(b17);
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
         self
     }

--- a/crates/rs1090/src/decode/cpr.rs
+++ b/crates/rs1090/src/decode/cpr.rs
@@ -22,7 +22,7 @@ use deku::prelude::*;
 use libm::fabs;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::str::FromStr;
 
@@ -75,6 +75,11 @@ fn haversine(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
 
 fn dist_haversine(pos1: &Position, pos2: &Position) -> f64 {
     haversine(pos1.latitude, pos1.longitude, pos2.latitude, pos2.longitude)
+}
+
+/// Great-circle distance between two positions in nautical miles.
+pub fn distance_nm(pos1: &Position, pos2: &Position) -> f64 {
+    dist_haversine(pos1, pos2) / 1.852
 }
 
 /// Check if a position is near any known airport
@@ -226,10 +231,100 @@ pub struct AircraftState {
     pos: Option<Position>,
     last_altitude: Option<i32>,
     pub airport: Option<String>,
+    /// BDS register codes the aircraft has been observed transmitting.
+    /// Updated after each successful (unambiguous) Comm-B decode.
+    pub seen_bds: BTreeSet<u8>,
+    /// Union of all BDS codes declared as supported (`true`) across every
+    /// surviving BDS 1,7 record for this aircraft.
+    pub supported_bds: BTreeSet<u8>,
+    /// Number of consistent BDS 1,7 records seen. Once this reaches the
+    /// threshold the capability set is considered stable enough to use as
+    /// a reject filter for unsupported BDS types.
+    pub bds17_count: u8,
     odd_ts: f64,
     odd_msg: Option<AirbornePosition>,
     even_ts: f64,
     even_msg: Option<AirbornePosition>,
+}
+
+impl AircraftState {
+    /// The most recent barometric altitude decoded for this aircraft, in feet.
+    pub fn last_altitude(&self) -> Option<i32> {
+        self.last_altitude
+    }
+
+    /// The most recent decoded position for this aircraft.
+    pub fn last_position(&self) -> Option<Position> {
+        self.pos
+    }
+
+    /// The set of BDS register codes this aircraft has been observed
+    /// transmitting. Used as evidence for the GICB bitmap tie-breaker.
+    pub fn seen_bds(&self) -> &BTreeSet<u8> {
+        &self.seen_bds
+    }
+
+    /// Record that a given BDS register code was observed for this aircraft.
+    pub fn record_bds(&mut self, code: u8) {
+        self.seen_bds.insert(code);
+    }
+
+    /// The minimum number of consistent BDS 1,7 records before the
+    /// capability set is used to reject unsupported BDS candidates.
+    const BDS17_STABILITY_THRESHOLD: u8 = 3;
+
+    /// Returns the set of BDS codes declared as supported across all
+    /// observed BDS 1,7 records, if enough records have been seen.
+    pub fn stable_supported_bds(&self) -> Option<&BTreeSet<u8>> {
+        if self.bds17_count >= Self::BDS17_STABILITY_THRESHOLD {
+            Some(&self.supported_bds)
+        } else {
+            None
+        }
+    }
+
+    /// Merge a new BDS 1,7 capability report into the per-aircraft
+    /// supported-BDS set. Call this after each unambiguous BDS 1,7 decode.
+    pub fn update_bds17(
+        &mut self,
+        report: &super::bds::bds17::CommonUsageGICBCapabilityReport,
+    ) {
+        // Union the true bits from this report into supported_bds.
+        if report.bds05 {
+            self.supported_bds.insert(0x05);
+        }
+        if report.bds06 {
+            self.supported_bds.insert(0x06);
+        }
+        if report.bds08 {
+            self.supported_bds.insert(0x08);
+        }
+        if report.bds09 {
+            self.supported_bds.insert(0x09);
+        }
+        if report.bds20 {
+            self.supported_bds.insert(0x20);
+        }
+        if report.bds21 {
+            self.supported_bds.insert(0x21);
+        }
+        if report.bds40 {
+            self.supported_bds.insert(0x40);
+        }
+        if report.bds44 {
+            self.supported_bds.insert(0x44);
+        }
+        if report.bds45 {
+            self.supported_bds.insert(0x45);
+        }
+        if report.bds50 {
+            self.supported_bds.insert(0x50);
+        }
+        if report.bds60 {
+            self.supported_bds.insert(0x60);
+        }
+        self.bds17_count = self.bds17_count.saturating_add(1);
+    }
 }
 
 /// NZ represents the number of latitude zones between the equator and a pole.
@@ -565,6 +660,9 @@ pub fn decode_position(
         pos: None,
         last_altitude: None,
         airport: None,
+        seen_bds: BTreeSet::new(),
+        supported_bds: BTreeSet::new(),
+        bds17_count: 0,
         odd_ts: timestamp,
         odd_msg: None,
         even_ts: timestamp,
@@ -664,6 +762,8 @@ pub fn decode_position(
                 latest.last_altitude = airborne.alt;
                 // Clear airport when airborne
                 latest.airport = None;
+                // Record that this aircraft transmits BDS 0,5
+                latest.record_bds(0x05);
                 // If necessary (according to the callback) update the reference position
                 if let Some(update_reference) = update_reference {
                     if update_reference(airborne) {
@@ -740,6 +840,8 @@ pub fn decode_position(
                 latest.timestamp = timestamp;
                 // Surface = on ground = no altitude
                 latest.last_altitude = None;
+                // Record that this aircraft transmits BDS 0,6
+                latest.record_bds(0x06);
                 // Find and store the nearest airport
                 if latest.airport.is_none() {
                     latest.airport =
@@ -747,7 +849,22 @@ pub fn decode_position(
                 }
             }
         }
-        _ => (),
+        _ => {
+            // For ADS-B message types other than BDS 0,5 and 0,6, record
+            // the BDS code in the aircraft's evidence set so the GICB
+            // bitmap tie-breaker can use it on subsequent messages.
+            let code: Option<u8> = match message {
+                ME::BDS08 { .. } => Some(0x08),
+                ME::BDS09(_) => Some(0x09),
+                ME::BDS61(_) => Some(0x61),
+                ME::BDS62(_) => Some(0x62),
+                ME::BDS65(_) => Some(0x65),
+                _ => None,
+            };
+            if let Some(code) = code {
+                latest.record_bds(code);
+            }
+        }
     }
 }
 

--- a/python/rs1090/__init__.py
+++ b/python/rs1090/__init__.py
@@ -130,6 +130,7 @@ __all__ = [
     "decode_bds45",
     "decode_bds50",
     "decode_bds60",
+    "decode_bds65",
     "flarm",
     "is_bds05",
     "is_bds06",

--- a/python/rs1090/stubs.py
+++ b/python/rs1090/stubs.py
@@ -304,7 +304,7 @@ class DF17_BDS65(TypedDict):
     df: Literal["17"]
     icao24: str
     bds: Literal["65"]
-    version: Literal["1", "2"]
+    version: Literal[0, 1, 2, 3, 4, 5, 6, 7]
     # NIC supplement A
     NICa: int
     # NIC Supplement bit (NICs)
@@ -410,7 +410,7 @@ class DF18_BDS65(TypedDict):
     ]
     icao24: str
     bds: Literal["65"]
-    version: Literal["1", "2"]
+    version: Literal[0, 1, 2, 3, 4, 5, 6, 7]
     # NIC supplement A
     NICa: int
     # NIC Supplement bit (NICs)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -274,7 +274,7 @@ fn decode_bds65(msg: String) -> PyResult<Vec<u8>> {
     let enum_id = &bytes[4] & 0b111;
     match (tc, enum_id) {
         (31, id) if id < 2 => {
-            match AircraftOperationStatus::from_bytes((&bytes[4..], 0)) {
+            match AircraftOperationStatus::from_bytes((&bytes[4..], 5)) {
                 Ok((_, msg)) => {
                     let pkl =
                         serde_pickle::to_vec(&msg, Default::default()).unwrap();

--- a/python/tests/test_adsb.py
+++ b/python/tests/test_adsb.py
@@ -53,6 +53,17 @@ def test_adsb_emergency() -> None:
     assert msg["squawk"] == "6513"
 
 
+def test_adsb_operational_status_version() -> None:
+    msg = rs1090.decode("903a33fff90200040049001ea8e2")
+    assert rs1090.is_df18(msg)
+    assert rs1090.is_bds65(msg)
+    assert msg["version"] == 2
+
+    bds65 = rs1090.decode_bds65("903a33fff90200040049001ea8e2")
+    assert bds65["version"] == 2
+    assert bds65["NACp"] == 9
+
+
 def test_adsb_target_state_status() -> None:
     msg = rs1090.decode("8DA05629EA21485CBF3F8CADAEEB")
     assert rs1090.is_df17(msg)


### PR DESCRIPTION
The work started from a dataset that is unusually useful for Comm-B inference: ASTERIX CAT048 monoradar reports from the ENRI secondary-surveillance radar site in Chofu, Tokyo. CAT048 carries the Mode S MB payload together with the BDS code requested by the interrogator. That gives us ground truth for a problem that passive receivers normally have to solve blind.

This matters because Comm-B replies (DF 20/21) carry a 56-bit MB payload, but the downlink does not include the BDS code. The code appears in the uplink interrogation, which normal ADS-B / Mode S feeders do not observe. A passive receiver like jet1090 must infer the register from the payload alone.

The paper we submitted shows that a protocol-only decoder accepts many wrong candidates, especially around BDS 0,5 / 2,1 / 4,0 / 4,5 / 5,0 / 6,0.

The CAT048 ground truth let us measure those false candidates directly, find decoder bugs that were hidden by spec-only testing, and tune a set of conservative inference rules. The default build now enables a stricter `bds-infer` feature. It keeps the existing structural decoders, then adds physical limits, density scoring, cross-field checks, registration validation, capability-history checks, and per-aircraft state checks. Builds without default features keep a minimal, protocol-only baseline.

## What changed

### `rs1090` BDS inference

- Added the default `bds-infer` feature.
- Added post-decode density scoring in `crates/rs1090/src/decode/bds/density.rs`.
- Added within-record penalties in `crates/rs1090/src/decode/bds/penalty.rs`.
- Applied stricter field limits for:
  - BDS 0,5 altitude,
  - BDS 2,1 registration placeholders,
  - BDS 4,0 selected altitude and QNH,
  - BDS 4,4 / 4,5 meteorological fields,
  - BDS 5,0 roll / TAS / groundspeed,
  - BDS 6,0 IAS / Mach / inertial vertical rate.
- Fixed or normalised decoder behaviour found during the IWAC analysis:
  - BDS 0,5 / 0,6 / 0,8 bit offset handling,
  - BDS 1,7 relaxed `bds20` capability bit,
  - BDS 2,1 dash-placeholder stripping,
  - BDS 4,4 temperature wrap-around fallback for the observed sign-bit firmware anomaly.
- Added `infer_bds(payload, icao24)` so BDS 2,1 candidates can be checked against ICAO-address-derived country registration patterns.

### Context-aware Comm-B sanitisation

`CommBContext` now carries per-aircraft context into DF 20/21 sanitisation:

- last barometric altitude,
- ICAO address,
- observed BDS register history,
- last decoded position,
- stable BDS 1,7 capability support set.

The sanitiser now applies:

- BDS 0,5 altitude vs reference altitude, with a 100 ft gate;
- BDS 2,1 registration pattern validation;
- winner-take-all for high-confidence byte-header registers BDS 1,0 / 2,0 / 3,0;
- GICB bitmap tie-breaker using observed transmission history;
- BDS 0,5 local CPR position vs last known position, with a 5 NM gate;
- rejection of candidates contradicted by stable BDS 1,7 capability reports.

`MessageProcessor` now mutates aircraft state and records surviving Comm-B candidates after sanitisation, so later messages can use the aircraft's history.

### CAT48 and CLI paths

- CAT48 decoding now passes `icao24` into BDS inference when available.
- `decode1090` and `jet1090` call `sanitize_commb().record_observed_bds()` so stateful rules receive updated evidence.
- `decode1090 file` documentation now mentions JSONL / Beast CSV inputs and `.gz` / `.7z` compressed files.

## Mapping to the IWAC paper notes

The implementation follows the rule families described in `scripts/iwac/paper/analysis/pipeline.md`:

| Paper family | Implemented here | Main files |
|---|---|---|
| φ — physical limits | field-reader hard gates and density score | `bds05.rs`, `bds21.rs`, `bds40.rs`, `bds44.rs`, `bds45.rs`, `bds50.rs`, `bds60.rs`, `density.rs` |
| X — cross consistency | TAS/GS, roll/track-rate, IAS/Mach, BDS 0,5 altitude vs reference altitude | `penalty.rs`, `commb.rs` |
| S — statistical rules | GICB dead bits, BDS 4,4 FOM/dead fields, BDS 4,5 dead hazards | `bds17.rs`, `bds18.rs`, `bds44.rs`, `bds45.rs` |
| P — pattern rules | BDS 2,1 country-pattern validation and byte-header winner-take-all | `bds21.rs`, `commb.rs`, `bds/mod.rs` |
| T — temporal/state rules | observed-BDS history, BDS 1,7 capability support, local CPR position gate | `cpr.rs`, `commb.rs`, `jet1090/src/main.rs`, `decode1090/src/file.rs` |

Two implementation details differ from the offline paper pipeline:

- The paper's CAT48-specific X2 rule compares BDS 0,5 altitude with CAT48 outer altitude. The library version uses the DF 20 altitude when present, otherwise the aircraft's last known barometric altitude.
- The paper's T2 rule compares BDS 0,5 CPR against CAT48 radar polar position. The library version uses the aircraft's last decoded position as the local CPR reference, which is available in normal passive decoding.


## Compatibility notes

- `rs1090` default features now include `bds-infer`.
- `--no-default-features` keeps the minimal protocol-only inference mode.
- `infer_bds` now takes an `Option<u32>` ICAO address.
- `MessageProcessor::new` now needs mutable aircraft state because it records observed BDS registers.

