### PR TITLE
fix: only spawn crossterm EventHandler in interactive mode

### DIFF
--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -397,7 +397,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         0
     };
 
-    let mut events = tui::EventHandler::new(width);
+    let mut events = if terminal.is_some() {
+        Some(tui::EventHandler::new(width))
+    } else {
+        None
+    };
 
     let mut references = BTreeMap::<u64, Option<Position>>::new();
     let mut sensors = BTreeMap::<u64, Sensor>::new();
@@ -484,6 +488,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(mut terminal) = terminal {
         let app_tui_task = app_tui.clone();
         let shared_tui = shared.clone();
+        let mut events =
+            events.take().expect("event handler in interactive mode");
         tokio::spawn(async move {
             loop {
                 if let Ok(event) = events.next().await {


### PR DESCRIPTION
## Problem

When jet1090 runs as a systemd service with `interactive = false`, it panics on startup:

```
thread 'tokio-rt-worker' panicked at crossterm-0.29.0/src/event/read.rs:39:30:
reader source not set
```

## Cause

Terminal init is correctly gated on `interactive` in `crates/jet1090/src/main.rs`:

```rust
let terminal = if options.interactive { Some(tui::init()?) } else { None };
```

But the event handler is constructed unconditionally, just below it:

```rust
let mut events = tui::EventHandler::new(width);
```

`EventHandler::new` immediately spawns a task that opens a `crossterm::event::EventStream` and polls it (`tui.rs`). Under systemd there's no TTY attached, so crossterm has no event source and panics on the first poll. The only thing that reads `events` lives inside the `if let Some(mut terminal) = terminal` block, so in headless mode we were constructing the handler, panicking, and never using it.

## Fix

Make `events` an `Option<EventHandler>` that's only constructed in interactive mode, the same way `terminal` is gated, then unwrap it inside the existing interactive block where it's guaranteed to be present. Interactive mode behaves exactly as before.