### PR TITLE
fix: register /icao24 route and align docs with endpoints

### DIFF
--- a/crates/jet1090/src/web.rs
+++ b/crates/jet1090/src/web.rs
@@ -112,9 +112,10 @@ pub async fn handle_rejection(
         code = StatusCode::NOT_FOUND;
         message = "Route not found, try one of /,\n\
             /all,\n\
+            /icao24,\n\
             /track?icao24={icao24},\n\
             /sensors or\n\
-            /airport?q={string}";
+            /airports?q={string}";
     } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
         code = StatusCode::METHOD_NOT_ALLOWED;
         message = "Only GET queries are supported";
@@ -150,9 +151,9 @@ pub async fn serve_web_api(shared: Arc<SharedState>, port: u16) {
         ))
     });
 
-    let shared_home = shared.clone();
-    let icao24 = warp::path::end()
-        .and(warp::any().map(move || shared_home.clone()))
+    let shared_icao24 = shared.clone();
+    let icao24 = warp::path("icao24")
+        .and(warp::any().map(move || shared_icao24.clone()))
         .and_then(
             |shared: Arc<SharedState>| async move { icao24(&shared).await },
         );

--- a/docs/output.md
+++ b/docs/output.md
@@ -81,9 +81,12 @@ If a `--serve-port` option is set, a REST API is set on `0.0.0.0` on the port of
 
 The following endpoint are provided:
 
-- `/`: returns a list of all visible `icao24` identifiers
+- `/`: returns an index page with the available routes
+- `/icao24`: returns a list of all visible `icao24` identifiers
 - `/all`: returns a list of all state vectors (the last valid field for each aircraft)
 - `/track?icao24=xxx`: returns a list of all received messages for a given aircraft.
+- `/sensors`: returns information about all sensors
+- `/airports?q=xxx`: returns a list of airports matching the query string
 
 !!! warning
 


### PR DESCRIPTION
`/icao24` is advertised on the REST API index page but returns 404.
Its handler was bound to `warp::path::end()` (the root path) instead of `warp::path("icao24")`.

This binds it to the right path and fixes up the docs and 404 message to match the endpoints that actually exist.