### PR TITLE
refactor: replace warp with axum for the REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,16 +349,20 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
+ "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -366,10 +370,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -380,14 +389,26 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -395,12 +416,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1521,15 +1536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,25 +1957,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1979,7 +1966,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -2036,30 +2023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http 0.2.12",
- "httpdate",
- "mime",
- "sha1 0.10.6",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.12",
 ]
 
 [[package]]
@@ -2121,17 +2084,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2142,23 +2094,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -2169,8 +2110,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2197,30 +2138,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -2229,9 +2146,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2247,8 +2164,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2264,7 +2181,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2277,18 +2194,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2552,6 +2469,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "jet1090"
 version = "0.6.0"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "clap_complete",
@@ -2575,10 +2493,10 @@ dependencies = [
  "soapysdr",
  "tokio",
  "toml",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
- "warp",
 ]
 
 [[package]]
@@ -2833,7 +2751,7 @@ checksum = "b2cbaa9728c106462e4f7a534dea8ad8d0ab50bcc370959365463b69513581af"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
- "base64 0.22.1",
+ "base64",
  "bcrypt-pbkdf",
  "bytes",
  "cbc",
@@ -2910,16 +2828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,24 +2863,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -3364,7 +3254,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -3857,7 +3747,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3894,7 +3784,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4124,7 +4014,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -4195,13 +4085,13 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4218,7 +4108,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4302,7 +4192,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hexlit",
- "http 1.4.0",
+ "http",
  "hyper-util",
  "libm",
  "makiko",
@@ -4318,7 +4208,7 @@ dependencies = [
  "soapysdr",
  "ssh2-config",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -4495,12 +4385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,6 +4486,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4801,16 +4696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f436607817a47de9b0716931dd874cd273993a69091d174222d0b9099c2f748b"
 dependencies = [
  "pkg-config",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5030,7 +4915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -5194,7 +5079,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5233,18 +5118,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -5252,7 +5125,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.28.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5327,18 +5200,18 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5416,11 +5289,26 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -5507,32 +5395,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1 0.10.6",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -5714,35 +5583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "headers",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "mime",
- "mime_guess",
- "multer",
- "percent-encoding",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "tokio-util",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/crates/jet1090/Cargo.toml
+++ b/crates/jet1090/Cargo.toml
@@ -21,6 +21,7 @@ sero = ['rs1090/sero']
 ssh = ['rs1090/ssh']
 
 [dependencies]
+axum = { version = "0.8.9", features = ["macros"] }
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["color", "derive", "wrap_help", "env"] }
 clap_complete = "4.6.3"
@@ -44,10 +45,10 @@ serde_json = "1.0.149"
 soapysdr = { version = "0.5.1", optional = true }
 tokio = { version = "1.52.1", features = ["full"] }
 toml = "1.1.2"
+tower-http = { version = "0.7.0", features = ["cors"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 url = "2.5.7"
-warp = "0.3.6"
 
 [[bin]]
 name = "jet1090"

--- a/crates/jet1090/src/web.rs
+++ b/crates/jet1090/src/web.rs
@@ -1,26 +1,27 @@
 use rs1090::data::airports::{Airport, AIRPORTS};
 
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Json, Response};
+use axum::routing::get;
+use axum::Router;
 use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
 use std::sync::Arc;
-use warp::http::StatusCode;
-use warp::reject::Rejection;
-use warp::reply::Reply;
-use warp::Filter;
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::snapshot::Snapshot;
 use crate::SharedState;
 
 /// Information required to ask for a trajectory
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 pub struct TrackQuery {
     icao24: String,
     since: Option<f64>,
 }
 
 /// Information required to search for airports
-#[derive(Serialize, Deserialize)]
-pub struct Query {
+#[derive(Deserialize)]
+pub struct AirportQuery {
     q: String,
 }
 
@@ -32,60 +33,47 @@ struct ErrorMessage {
 }
 
 /// Returns all the ICAO 24-bit addresses of aircraft seen by jet1090
-pub async fn icao24(
-    shared: &Arc<SharedState>,
-) -> Result<warp::reply::Json, Infallible> {
+async fn icao24(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
     let state_vectors = shared.state_vectors.read().await;
     let keys: Vec<_> =
         state_vectors.keys().map(|key| key.to_string()).collect();
-    Ok::<_, Infallible>(warp::reply::json(&keys))
+    Json(keys)
 }
 
 /// Returns all state vectors without any history information
-pub async fn all(
-    shared: &Arc<SharedState>,
-) -> Result<warp::reply::Json, Infallible> {
+async fn all(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
     let state_vectors = shared.state_vectors.read().await;
-    Ok::<_, Infallible>(warp::reply::json(
-        &state_vectors
-            .values()
-            .map(|sv| &sv.cur)
-            .collect::<Vec<&Snapshot>>(),
-    ))
+    let snapshots: Vec<&Snapshot> =
+        state_vectors.values().map(|sv| &sv.cur).collect();
+    Json(
+        serde_json::to_value(snapshots)
+            .unwrap_or(serde_json::Value::Array(vec![])),
+    )
 }
 
 /// Returns the trajectory of a given aircraft matching the REST query
-pub async fn track(
-    shared: &Arc<SharedState>,
-    q: TrackQuery,
-) -> Result<warp::reply::Json, Infallible> {
+async fn track(
+    State(shared): State<Arc<SharedState>>,
+    Query(q): Query<TrackQuery>,
+) -> impl IntoResponse {
     let state_vectors = shared.state_vectors.read().await;
     let res = state_vectors.get(&q.icao24).map(|sv| &sv.hist);
-    let res = match q.since {
-        Some(since) => {
-            let res = res.map(|res| {
-                res.iter()
-                    .filter(|m| m.timestamp > since)
-                    .collect::<Vec<_>>()
-            });
-            // Option<Vec<&TimedMessage>>
-            warp::reply::json(&res)
-        }
-        // Option<&Vec<TimedMessage>>
-        None => warp::reply::json(&res),
-    };
-    Ok::<_, Infallible>(res)
+    match q.since {
+        Some(since) => Json(serde_json::json!(res.map(|r| r
+            .iter()
+            .filter(|m| m.timestamp > since)
+            .collect::<Vec<_>>()))),
+        None => Json(serde_json::json!(res)),
+    }
 }
 
 /// Returns decoding information about all sensors
-pub async fn sensors(
-    shared: &Arc<SharedState>,
-) -> Result<warp::reply::Json, Infallible> {
-    Ok::<_, Infallible>(warp::reply::json(&shared.sensors))
+async fn sensors(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
+    Json(shared.sensors.clone())
 }
 
-/// Returns a list of poential airports matching the query string
-pub async fn airports(query: Query) -> Result<warp::reply::Json, Infallible> {
+/// Returns a list of potential airports matching the query string
+async fn airports(Query(query): Query<AirportQuery>) -> impl IntoResponse {
     let lowercase = query.q.to_lowercase();
     let res: Vec<&Airport> = AIRPORTS
         .iter()
@@ -96,102 +84,58 @@ pub async fn airports(query: Query) -> Result<warp::reply::Json, Infallible> {
                 || a.iata.to_lowercase().contains(&lowercase)
         })
         .collect();
-    Ok::<_, Infallible>(warp::reply::json(&res))
+    Json(res)
 }
 
-/// Returns proper error messages in JSON format
-pub async fn handle_rejection(
-    err: Rejection,
-) -> Result<impl Reply, Infallible> {
-    // https://github.com/seanmonstar/warp/blob/master/examples/rejections.rs
+/// Home page with API documentation
+async fn home() -> Html<&'static str> {
+    Html(
+        "Welcome to the jet1090 REST API!<br>\
+        Try one of the following routes:<br>\
+        <ul>\
+        <li><a href=\"/all\">/all</a>: returns all current state vectors</li>\
+        <li><a href=\"/icao24\">/icao24</a>: returns all ICAO 24-bit addresses seen</li>\
+        <li>/track?icao24={icao24}&amp;since={timestamp}: returns the trajectory of a given aircraft since the given timestamp (optional)</li>\
+        <li><a href=\"/sensors\">/sensors</a>: returns information about all sensors</li>\
+        <li>/airports?q={string}: returns a list of potential airports matching the query string</li>\
+        </ul>",
+    )
+}
 
-    let code;
-    let message;
-
-    if err.is_not_found() {
-        code = StatusCode::NOT_FOUND;
-        message = "Route not found, try one of /,\n\
-            /all,\n\
-            /icao24,\n\
-            /track?icao24={icao24},\n\
-            /sensors or\n\
-            /airports?q={string}";
-    } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
-        code = StatusCode::METHOD_NOT_ALLOWED;
-        message = "Only GET queries are supported";
-    } else if err.find::<warp::reject::InvalidQuery>().is_some() {
-        code = StatusCode::BAD_REQUEST;
-        message = "Invalid query";
-    } else {
-        eprintln!("unhandled rejection: {err:?}");
-        code = StatusCode::INTERNAL_SERVER_ERROR;
-        message = "Unknown error";
-    }
-
-    let json = warp::reply::json(&ErrorMessage {
-        code: code.as_u16(),
-        message: message.into(),
-    });
-
-    Ok(warp::reply::with_status(json, code))
+/// Fallback handler for unknown routes
+async fn not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorMessage {
+            code: StatusCode::NOT_FOUND.as_u16(),
+            message: "Route not found, try one of /, /all, /icao24, /track?icao24={icao24}, /sensors or /airports?q={string}".into(),
+        }),
+    )
+        .into_response()
 }
 
 pub async fn serve_web_api(shared: Arc<SharedState>, port: u16) {
-    let home = warp::path::end().and_then(|| async {
-        Ok::<_, Infallible>(warp::reply::html(
-            "Welcome to the jet1090 REST API!<br>\
-            Try one of the following routes:<br>\
-            <ul>\
-            <li><a href=\"/all\">/all</a>: returns all current state vectors</li>\
-            <li><a href=\"/icao24\">/icao24</a>: returns all ICAO 24-bit addresses seen</li>\
-            <li>/track?icao24={icao24}&since={timestamp}: returns the trajectory of a given aircraft since the given timestamp (optional)</li>\
-            <li><a href=\"/sensors\">/sensors</a>: returns information about all sensors</li>\
-            <li>/airports?q={string}: returns a list of potential airports matching the query string</li>\
-            </ul>",
-        ))
-    });
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_headers(Any)
+        .allow_methods(Any);
 
-    let shared_icao24 = shared.clone();
-    let icao24 = warp::path("icao24")
-        .and(warp::any().map(move || shared_icao24.clone()))
-        .and_then(
-            |shared: Arc<SharedState>| async move { icao24(&shared).await },
-        );
+    let app = Router::new()
+        .route("/", get(home))
+        .route("/icao24", get(icao24))
+        .route("/all", get(all))
+        .route("/track", get(track))
+        .route("/sensors", get(sensors))
+        .route("/airports", get(airports))
+        .fallback(not_found)
+        .with_state(shared)
+        .layer(cors);
 
-    let shared_all = shared.clone();
-    let all = warp::path("all")
-        .and(warp::any().map(move || shared_all.clone()))
-        .and_then(|shared: Arc<SharedState>| async move { all(&shared).await });
-
-    let shared_track = shared.clone();
-    let track = warp::get()
-        .and(warp::path("track"))
-        .and(warp::any().map(move || shared_track.clone()))
-        .and(warp::query::<TrackQuery>())
-        .and_then(|shared: Arc<SharedState>, q: TrackQuery| async move {
-            track(&shared, q).await
-        });
-
-    let shared_sensors = shared.clone();
-    let sensors = warp::path("sensors")
-        .and(warp::any().map(move || shared_sensors.clone()))
-        .and_then(
-            |shared: Arc<SharedState>| async move { sensors(&shared).await },
-        );
-
-    let airports = warp::path("airports")
-        .and(warp::query::<Query>())
-        .and_then(|query: Query| async move { airports(query).await });
-
-    let cors = warp::cors()
-        .allow_any_origin()
-        .allow_headers(vec!["*"])
-        .allow_methods(vec!["GET"]);
-
-    let routes = warp::get()
-        .and(home.or(icao24).or(all).or(track).or(sensors).or(airports))
-        .recover(handle_rejection)
-        .with(cors);
-
-    warp::serve(routes).run(([0, 0, 0, 0], port)).await;
+    let listener =
+        tokio::net::TcpListener::bind((std::net::Ipv4Addr::UNSPECIFIED, port))
+            .await
+            .expect("failed to bind port");
+    axum::serve(listener, app)
+        .await
+        .expect("web API server error");
 }


### PR DESCRIPTION
warp 0.4 has a known upstream regression (`implementation of Reply is not general enough`, seanmonstar/warp#...) with no fix in sight. axum is the modern successor in the same Tokio ecosystem, built on hyper 1.0, and actively maintained.

## Changes
- Remove `warp` dependency, add `axum 0.8` + `tower-http` (CORS layer)
- Rewrite `web.rs` using axum `Router`, `State` extractor, and `IntoResponse`
- Replace warp Filter combinators with plain async route handlers
- Replace `warp::cors()` with `tower_http::cors::CorsLayer`
- Replace `warp::serve().run()` with `axum::serve(TcpListener, app)`

Same 6 endpoints, same CORS policy, same behaviour.