### PR TITLE
fix: address Rust 1.97 Clippy lints

### DIFF
--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -641,7 +641,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Periodically update all sensor references to lowest aircraft position
         if msg.timestamp - last_reference_update > 300.0 {
-            for (_, reference) in references.iter_mut() {
+            for reference in references.values_mut() {
                 rs1090::decode::cpr::update_global_reference(
                     &aircraft,
                     reference,

--- a/crates/rs1090/examples/airports.rs
+++ b/crates/rs1090/examples/airports.rs
@@ -4,7 +4,7 @@ use rs1090::data::airports::AIRPORTS;
 pub fn main() {
     let args: Vec<Regex> = std::env::args()
         .skip(1)
-        .map(|a| Regex::new(&format!("(?i){}", &a)).unwrap())
+        .map(|a| Regex::new(&format!("(?i){}", a)).unwrap())
         .collect();
 
     'airport: for airport in AIRPORTS.iter() {

--- a/crates/rs1090/src/data/airports.rs
+++ b/crates/rs1090/src/data/airports.rs
@@ -21,8 +21,8 @@ impl Display for Airport {
         write!(f, "{}", Color::RGB(0, 128, 0).bold().paint(&self.icao))?;
         write!(f, " - ")?;
         write!(f, "{}", Color::RGB(255, 69, 0).paint(&self.iata))?;
-        write!(f, "    {:.3} {:.3}\t", &self.lat, &self.lon)?;
-        write!(f, "{} ({})", &self.name, &self.country)
+        write!(f, "    {:.3} {:.3}\t", self.lat, self.lon)?;
+        write!(f, "{} ({})", self.name, self.country)
     }
 }
 

--- a/crates/rs1090/src/decode/adsb.rs
+++ b/crates/rs1090/src/decode/adsb.rs
@@ -36,9 +36,9 @@ pub struct ADSB {
 impl fmt::Display for ADSB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, " DF17. Extended Squitter")?;
-        writeln!(f, "  Address:       {}", &self.icao24)?;
-        writeln!(f, "  Air/Ground:    {}", &self.capability)?;
-        write!(f, "{}", &self.message)
+        writeln!(f, "  Address:       {}", self.icao24)?;
+        writeln!(f, "  Air/Ground:    {}", self.capability)?;
+        write!(f, "{}", self.message)
     }
 }
 

--- a/crates/rs1090/src/decode/bds/bds08.rs
+++ b/crates/rs1090/src/decode/bds/bds08.rs
@@ -342,8 +342,8 @@ pub fn callsign_read<R: deku::no_std_io::Read + deku::no_std_io::Seek>(
 impl fmt::Display for AircraftIdentification {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "  Aircraft identification and category (BDS 0,8)")?;
-        writeln!(f, "  Callsign:      {}", &self.callsign)?;
-        writeln!(f, "  Category:      {}", &self.wake_vortex)?;
+        writeln!(f, "  Callsign:      {}", self.callsign)?;
+        writeln!(f, "  Category:      {}", self.wake_vortex)?;
         Ok(())
     }
 }

--- a/crates/rs1090/src/decode/bds/bds09.rs
+++ b/crates/rs1090/src/decode/bds/bds09.rs
@@ -683,9 +683,9 @@ impl fmt::Display for AirborneVelocity {
             | AirborneVelocitySubType::Reserved1(_) => {}
         }
         if let Some(vr) = &self.vertical_rate {
-            writeln!(f, "  Vertical rate: {} ft/min {}", vr, &self.vrate_src)?;
+            writeln!(f, "  Vertical rate: {} ft/min {}", vr, self.vrate_src)?;
         }
-        writeln!(f, "  NACv:          {}", &self.nac_v)?;
+        writeln!(f, "  NACv:          {}", self.nac_v)?;
         if let Some(value) = &self.geo_minus_baro {
             writeln!(f, "  GNSS delta:    {value} ft")?;
         }

--- a/crates/rs1090/src/decode/bds/bds61.rs
+++ b/crates/rs1090/src/decode/bds/bds61.rs
@@ -99,8 +99,8 @@ pub struct AircraftStatus {
 impl fmt::Display for AircraftStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "  Aircraft Status (BDS 6,1)")?;
-        writeln!(f, "  Squawk:        {:x?}", &self.squawk)?;
-        writeln!(f, "  Emergency/priority:    {}", &self.emergency_state)?;
+        writeln!(f, "  Squawk:        {:x?}", self.squawk)?;
+        writeln!(f, "  Emergency/priority:    {}", self.emergency_state)?;
         Ok(())
     }
 }

--- a/crates/rs1090/src/decode/bds/bds62.rs
+++ b/crates/rs1090/src/decode/bds/bds62.rs
@@ -350,11 +350,7 @@ impl fmt::Display for TargetStateAndStatusInformation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "  Target state and status (BDS 6,2)")?;
         if let Some(sel_alt) = &self.selected_altitude {
-            writeln!(
-                f,
-                "  Selected alt:  {} ft {}",
-                sel_alt, &self.alt_source
-            )?;
+            writeln!(f, "  Selected alt:  {} ft {}", sel_alt, self.alt_source)?;
         }
         if let Some(sel_hdg) = &self.selected_heading {
             writeln!(f, "  Selected hdg:  {sel_hdg:.1}°")?;

--- a/crates/rs1090/src/decode/mod.rs
+++ b/crates/rs1090/src/decode/mod.rs
@@ -563,7 +563,7 @@ where
 
 impl fmt::Display for TimedMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{:.5},{}", &self.timestamp, hex::encode(&self.frame))?;
+        writeln!(f, "{:.5},{}", self.timestamp, hex::encode(&self.frame))?;
         if let Some(msg) = &self.message {
             writeln!(f, "{msg}")?;
         }
@@ -572,7 +572,7 @@ impl fmt::Display for TimedMessage {
 }
 impl fmt::Debug for TimedMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{:.5},{}", &self.timestamp, hex::encode(&self.frame))?;
+        writeln!(f, "{:.5},{}", self.timestamp, hex::encode(&self.frame))?;
         if let Some(msg) = &self.message {
             writeln!(f, "{msg:#}")?;
         }

--- a/crates/rs1090/src/source/ssh.rs
+++ b/crates/rs1090/src/source/ssh.rs
@@ -350,7 +350,7 @@ impl TunnelledTcp {
                 .map_err(|e| {
                     let msg = format!(
                         "Could not connect to jump host {}: {}",
-                        &self.jump, e
+                        self.jump, e
                     );
                     BoxError::from(msg)
                 })?;
@@ -379,7 +379,7 @@ impl TunnelledWebsocket {
                 .map_err(|e| {
                     let msg = format!(
                         "Could not connect to jump host {}: {}",
-                        &self.jump, e
+                        self.jump, e
                     );
                     BoxError::from(msg)
                 })?;


### PR DESCRIPTION
Remove redundant borrows in formatting macros and use values_mut() as required by Rust 1.97 Clippy. This restores the shared Rust check currently blocking Dependabot PRs.